### PR TITLE
Ajoute le sélecteur de thème dans le footer

### DIFF
--- a/inertia/pages/layout.tsx
+++ b/inertia/pages/layout.tsx
@@ -1,4 +1,5 @@
 import { Header } from '@codegouvfr/react-dsfr/Header'
+import { headerFooterDisplayItem } from '@codegouvfr/react-dsfr/Display'
 import { Footer } from '@codegouvfr/react-dsfr/Footer'
 
 export default function Layout({
@@ -26,13 +27,8 @@ export default function Layout({
       {!hideFooter && (
         <Footer
           accessibility="fully compliant"
+          bottomItems={[headerFooterDisplayItem]}
           contentDescription=""
-          termsLinkProps={{
-            href: '#',
-          }}
-          websiteMapLinkProps={{
-            href: '#',
-          }}
         />
       )}
     </div>


### PR DESCRIPTION
Cette PR ajoute le sélecteur de thème dans le Footer

## Captures : 

<img width="546" height="252" alt="image" src="https://github.com/user-attachments/assets/0e3a03cf-4a04-43b0-9be5-3d010d7d1433" />

<img width="457" height="605" alt="image" src="https://github.com/user-attachments/assets/0dde3096-f1d8-4974-9783-8f0c934043ef" />
