### PR TITLE
Outil de développement: Ajout d'un seeder pour exploitations et contacts

### DIFF
--- a/database/seeders/exploitation_seeder.ts
+++ b/database/seeders/exploitation_seeder.ts
@@ -1,0 +1,10 @@
+import { BaseSeeder } from '@adonisjs/lucid/seeders'
+import { ExploitationFactory } from '#database/factories/exploitation_factory'
+
+export default class extends BaseSeeder {
+  static environment = ['development']
+
+  async run() {
+    await ExploitationFactory.with('contacts', 1).createMany(25)
+  }
+}


### PR DESCRIPTION
La commande `node ace db:seed` créé maintenant un jeu de données de 25 exploitations avec un contact renseigné, uniquement dans un environnement de développement (piloté par la variable d'environnement NODE_ENV).