### PR TITLE
Corriger les noms de classe des icônes sur storybook

### DIFF
--- a/inertia/ui/LabelInfo/label-info.stories.tsx
+++ b/inertia/ui/LabelInfo/label-info.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
     },
   },
   args: {
-    icon: 'info-line',
+    icon: 'fr-icon-info-line',
     label: 'Label',
     info: 'info',
     size: 'md',

--- a/inertia/ui/SectionCard/section-card.stories.tsx
+++ b/inertia/ui/SectionCard/section-card.stories.tsx
@@ -43,8 +43,8 @@ const meta = {
   },
   args: {
     title: 'Titre de la section',
-    icon: 'map-pin-2-line',
-    actionIcon: 'edit-line',
+    icon: 'fr-icon-map-pin-2-line',
+    actionIcon: 'fr-icon-edit-line',
     actionLabel: 'Modifier',
     size: 'medium',
     background: 'primary',

--- a/inertia/ui/SmallSection/small-section.stories.tsx
+++ b/inertia/ui/SmallSection/small-section.stories.tsx
@@ -46,7 +46,7 @@ const meta = {
   },
   args: {
     title: 'Titre de la petite section',
-    actionIcon: 'add-circle-line',
+    actionIcon: 'fr-icon-add-circle-line',
     actionLabel: 'Ajouter',
     handleAction: () => {
       alert('Action déclenchée !')


### PR DESCRIPTION
Cette requête pull met à jour les identifiants d'icônes dans plusieurs fichiers Storybook story pour utiliser la nouvelle convention de dénomination `fr-icon-*`. Cela garantit la cohérence avec la bibliothèque d'icônes et empêche les inadéquations potentielles ou les icônes manquantes dans les composants de l'interface utilisateur.

Mises à jour de l'identifiant d'icône:

* Modification de la propriété `icon` de `'info-line'` à `'fr-icon-info-line'` dans `label-info.stories.tsx`.
* Mise à jour des propriétés `icon` et `actionIcon` en `'fr-icon-map-pin-2-line'` et `'fr-icon-edit-line'' respectivement dans `section-card.stories.tsx`.
* Modification de la propriété `actionIcon` de `'add-circle-line'` à `'fr-icon-add-circle-line'` dans `small-section.stories.tsx`.