### PR TITLE
Prévisualisation des thèmes dark/light

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -4,11 +4,10 @@ import '@codegouvfr/react-dsfr/dsfr/dsfr.css'
 import '@codegouvfr/react-dsfr/dsfr/utility/icons/icons.css'
 import '../inertia/css/app.css'
 import { startReactDsfr } from '@codegouvfr/react-dsfr/spa'
+import React from 'react'
+import type { Decorator } from '@storybook/react'
 
-startReactDsfr({
-  defaultColorScheme: 'light',
-  useLang: () => 'fr',
-})
+startReactDsfr({ defaultColorScheme: 'system' })
 
 const preview: Preview = {
   parameters: {
@@ -26,6 +25,43 @@ const preview: Preview = {
       test: 'todo',
     },
   },
+
+  argTypes: {
+    theme: {
+      control: { type: 'radio' },
+      options: ['light', 'dark'],
+      description: 'Thème DSFR (light ou dark)',
+      table: {
+        category: 'Thème',
+        defaultValue: { summary: 'light' },
+      },
+    },
+  },
+
+  args: {
+    theme: 'light',
+  },
+
+  decorators: [
+    ((Story, context) => {
+      const theme = (context.args.theme as string) || 'light'
+      const backgroundColor = theme === 'dark' ? '#1e1e1e' : '#ffffff'
+
+      // Appliquer le thème sur la balise html
+      React.useEffect(() => {
+        if (typeof document !== 'undefined') {
+          document.documentElement.setAttribute('data-fr-scheme', theme)
+          document.documentElement.style.colorScheme = theme
+        }
+      }, [theme])
+
+      return React.createElement(
+        'div',
+        { style: { backgroundColor, padding: '1rem' } },
+        React.createElement(Story)
+      )
+    }) as Decorator,
+  ],
 }
 
 export default preview


### PR DESCRIPTION
Cette demande de tirage met à jour la configuration de Storybook pour améliorer la prise en charge des thèmes et l'expérience utilisateur. Les principaux changements sont le passage à un schéma de couleurs par défaut basé sur le système, l'ajout d'une bascule de thème pour les stories Storybook et la mise en œuvre d'un décorateur pour appliquer dynamiquement le thème sélectionné.

**Prise en charge et configuration du thème:**

* A modifié l'initialisation DSFR dans `.storybook/preview.ts` pour utiliser `defaultColorScheme: 'system'' au lieu de hardcoding 'light', permettant au thème de suivre les préférences du système.
* Ajout d'une entrée `argTypes` pour `thème` avec des commandes radio pour 'lumière' et 'sombre', permettant aux utilisateurs de changer de thème dans l'interface utilisateur Storybook.
* Définir par défaut `args` pour le thème à 'allumer' dans Storybook, en assurant une apparence initiale cohérente.

**Application de thème dynamique:**

* Implémenté un décorateur Storybook qui applique le thème sélectionné à l'élément racine HTML et définit la couleur d'arrière-plan en conséquence, en assurant le rendu des composants avec le thème DSFR correct.