### PR TITLE
Route API de recherche d'exploitation active par Siret

### DIFF
--- a/app/controllers/exploitations_controller.ts
+++ b/app/controllers/exploitations_controller.ts
@@ -56,6 +56,15 @@ export default class ExploitationsController {
     })
   }
 
+  async getBySiret({ params, response }: HttpContext) {
+    const exploitation = await this.exploitationService
+      .queryActiveExploitations()
+      .where({ siret: params.siret })
+      .first()
+
+    return response.json(exploitation)
+  }
+
   async store({ request, session, response }: HttpContext) {
     const {
       contactFirstName,

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -30,6 +30,9 @@ router
       .as('exploitations.create')
 
     router.get('exploitations/:id', [ExploitationsController, 'get']).as('exploitations.get')
+    router
+      .get('exploitations/siret/:siret', [ExploitationsController, 'getBySiret'])
+      .as('exploitations.getBySiret')
 
     router
       .post('exploitations/creation', [ExploitationsController, 'store'])

--- a/tests/functional/exploitation/exploitation_get.spec.ts
+++ b/tests/functional/exploitation/exploitation_get.spec.ts
@@ -1,0 +1,35 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { UserFactory } from '#database/factories/user_factory'
+import { ExploitationFactory } from '#database/factories/exploitation_factory'
+
+test.group('Exploitation - Get Resource', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('I can get an active exploitation by siret', async ({ assert, client, route }) => {
+    const siret = '12345678901234'
+    const user = await UserFactory.create()
+    const exploitation = await ExploitationFactory.merge({ siret }).create()
+
+    const response = await client.get(route('exploitations.getBySiret', { siret })).loginAs(user)
+
+    response.assertStatus(200)
+    const responseBody = response.body()
+    assert.equal(responseBody.id, exploitation.id)
+    assert.equal(responseBody.siret, siret)
+  })
+
+  test("Getting an exploitation by siret that doesn't exist returns an empty object", async ({
+    assert,
+    client,
+    route,
+  }) => {
+    const siret = '00000000000000'
+    const user = await UserFactory.create()
+
+    const response = await client.get(route('exploitations.getBySiret', { siret })).loginAs(user)
+
+    response.assertStatus(204)
+    assert.deepEqual(response.body(), {})
+  })
+})


### PR DESCRIPTION
Cette route sert aux formulaires de création/édition d'exploitations pour faire gagner du temps à l'utilisateur.