### PR TITLE
Les données du tableau d'exploitations sont maintenant cliquables

### DIFF
--- a/inertia/components/exploitations/exploitations-table.tsx
+++ b/inertia/components/exploitations/exploitations-table.tsx
@@ -1,6 +1,16 @@
 import { Table } from '@codegouvfr/react-dsfr/Table'
 import { ExploitationJson } from '../../../types/models'
 import { displayContactName } from '~/functions/contacts'
+import { Link } from '@inertiajs/react'
+import { ComponentProps } from 'react'
+
+function TableLinkCell({ children, ...props }: ComponentProps<typeof Link>) {
+  return (
+    <Link className="block bg-none! p-4!" tabIndex={0} {...props}>
+      {children}
+    </Link>
+  )
+}
 
 export default function ExploitationsTable({
   exploitations = [],
@@ -9,36 +19,46 @@ export default function ExploitationsTable({
 }) {
   return (
     exploitations.length > 0 && (
-      <div>
-        <Table
-          bordered
-          fixed
-          headers={[
-            <div>
-              <span className="fr-icon-map-pin-user-line fr-icon--sm" /> Organisation
-            </div>,
-            <div>
-              <span className="fr-icon-user-line fr-icon--sm" /> Utilisateur
-            </div>,
-            <div>
-              <span className="fr-icon-mail-line fr-icon--sm" /> Email
-            </div>,
-            <div>
-              <span className="fr-icon-phone-line fr-icon--sm" /> Téléphone
-            </div>,
-            <div>
-              <span className="fr-icon-map-pin-2-line fr-icon--sm" /> Localisation
-            </div>,
-          ]}
-          data={exploitations.map((exploitation) => [
-            [exploitation.name],
-            [displayContactName(exploitation?.contacts?.[0])],
-            [exploitation.contacts?.[0]?.email || 'N/A'],
-            [exploitation.contacts?.[0]?.phoneNumber || 'N/A'],
-            [exploitation.commune || 'N/A'],
-          ])}
-        />
-      </div>
+      <Table
+        bordered
+        fixed
+        className="[&_td]:p-0!"
+        headers={[
+          <div>
+            <span className="fr-icon-map-pin-user-line fr-icon--sm" /> Organisation
+          </div>,
+          <div>
+            <span className="fr-icon-user-line fr-icon--sm" /> Utilisateur
+          </div>,
+          <div>
+            <span className="fr-icon-mail-line fr-icon--sm" /> Email
+          </div>,
+          <div>
+            <span className="fr-icon-phone-line fr-icon--sm" /> Téléphone
+          </div>,
+          <div>
+            <span className="fr-icon-map-pin-2-line fr-icon--sm" /> Localisation
+          </div>,
+        ]}
+        data={exploitations.map((exploitation) => {
+          const LinkCell = ({ children }: ComponentProps<typeof Link>) => (
+            <TableLinkCell
+              href={`/exploitations/${exploitation.id}`}
+              aria-label={`Voir les détails de l'exploitation ${exploitation.name}`}
+            >
+              {children}
+            </TableLinkCell>
+          )
+
+          return [
+            [<LinkCell>{exploitation.name}</LinkCell>],
+            [<LinkCell>{displayContactName(exploitation?.contacts?.[0])}</LinkCell>],
+            [<LinkCell>{exploitation.contacts?.[0]?.email || 'N/A'}</LinkCell>],
+            [<LinkCell>{exploitation.contacts?.[0]?.phoneNumber || 'N/A'}</LinkCell>],
+            [<LinkCell>{exploitation.commune || 'N/A'}</LinkCell>],
+          ]
+        })}
+      />
     )
   )
 }


### PR DESCRIPTION
<img width="1422" height="961" alt="image" src="https://github.com/user-attachments/assets/fdf356eb-1f8c-4a5c-8bea-e9d683c0cc22" />

On peut maintenant accéder à la page unique d'une exploitation via cette vue tableau.

Fix #69 