### PR TITLE
Correction de l'affichage dans le formulaire d'édition

### DIFF
--- a/inertia/components/exploitations/form/exploitation-identification.tsx
+++ b/inertia/components/exploitations/form/exploitation-identification.tsx
@@ -81,7 +81,7 @@ export default function ExploitationIdentification({
                     nativeInputProps={{
                       placeholder: 'Entrer le nom de l’exploitation',
                       defaultValue:
-                        exploitationIdentification?.nom_complet || exploitationIdentification?.name,
+                        exploitationIdentification?.name || exploitationIdentification?.nom_complet,
                       onChange: (e) => {
                         setExploitationIdentification({
                           ...exploitationIdentification,


### PR DESCRIPTION
Ces modifications corrigent l'affichage du nom de l'exploitation lors de l'édition.

On affiche maintenant la propriété `name` en priorité, et pas le champ `nom_complet` utilisé uniquement lorsque le champ `name` n'est pas renseigné.