### PR TITLE
Ajout d'une confirmation pour supprimer une exploitation

### DIFF
--- a/inertia/pages/exploitations/id.tsx
+++ b/inertia/pages/exploitations/id.tsx
@@ -100,7 +100,7 @@ export default function SingleExploitation({
               />
               <div className="fr-mt-3w">
                 <Input
-                  label="Pour confirmer la suppression, veuillez taper le nom de l'exploitation :"
+                  label={`Pour confirmer la suppression, veuillez taper "${exploitation.name}" :`}
                   nativeInputProps={{
                     placeholder: exploitation.name,
                     onChange: (e) => {


### PR DESCRIPTION
Ces modifications ajoutent une condition pour la suppression d'une exploitation.

Lorsque l'utilisateur souhaite supprimer une exploitation, il devra maintenant confirmer la suppression en tapant le nom de l'exploitation afin de débloquer le bouton de suppression.

## Captures 

<img width="1377" height="980" alt="image" src="https://github.com/user-attachments/assets/b0006944-2bd0-4760-815e-26d848a39533" />

<img width="1377" height="980" alt="image" src="https://github.com/user-attachments/assets/f7e00bba-228b-4cf1-831f-1965c88278eb" />

Fix #26 