### PR TITLE
Correction du problème de "flash" en mode sombre

### DIFF
--- a/inertia/app/app.tsx
+++ b/inertia/app/app.tsx
@@ -6,12 +6,17 @@ import '@codegouvfr/react-dsfr/dsfr/dsfr.css'
 import '@codegouvfr/react-dsfr/dsfr/utility/icons/icons.css'
 import '../css/app.css'
 import { hydrateRoot } from 'react-dom/client'
-import { createInertiaApp } from '@inertiajs/react'
+import { createInertiaApp, Link } from '@inertiajs/react'
 import { resolvePageComponent } from '@adonisjs/inertia/helpers'
 import { startReactDsfr } from '@codegouvfr/react-dsfr/spa'
 import { fr } from '@codegouvfr/react-dsfr'
 
-startReactDsfr({ defaultColorScheme: 'system' })
+startReactDsfr({ defaultColorScheme: 'system', Link })
+declare module '@codegouvfr/react-dsfr/spa' {
+  interface RegisterLink {
+    Link: typeof Link
+  }
+}
 
 const appName = import.meta.env.VITE_APP_NAME || 'Viz’Eau'
 


### PR DESCRIPTION
Ces modifications suppriment le "flash" qu'on pouvait voir lorsque le site est en mode sombre.

## Captures : 

### Avant : 

https://github.com/user-attachments/assets/9bc7a79b-8151-4599-9149-30a3ed1d4965

### Après : 


https://github.com/user-attachments/assets/85b5d825-707f-4b14-ab6e-db2fd0058c60

