### PR TITLE
Les utilisateurs ne peuvent plus supprimer les tags appartenant à quelqu'un d'autre

### DIFF
--- a/app/controllers/log_entries_controller.ts
+++ b/app/controllers/log_entries_controller.ts
@@ -108,11 +108,13 @@ export default class LogEntriesController {
     return response.redirect().back()
   }
 
-  async destroyTagForExploitation({ request, response, session, logger }: HttpContext) {
+  async destroyTagForExploitation({ auth, request, response, session, logger }: HttpContext) {
     const payload = await request.validateUsing(deleteLogEntryTagValidator)
 
+    const user = auth.getUserOrFail()
+
     try {
-      await this.logEntryTagService.deleteTag(payload.tagId, payload.params.exploitationId)
+      await this.logEntryTagService.deleteTag(payload.tagId, payload.params.exploitationId, user.id)
     } catch (error) {
       logger.error('Error deleting tag:', error)
       createErrorFlashMessage(

--- a/app/dto/log_entry_tag_dto.ts
+++ b/app/dto/log_entry_tag_dto.ts
@@ -8,6 +8,10 @@ export class LogEntryTagDto {
     return {
       id: tag.id,
       name: tag.name,
+      userId: tag.userId,
+      exploitationId: tag.exploitationId,
+      createdAt: tag.createdAt.toISO() as string,
+      updatedAt: tag.updatedAt.toISO() as string,
     }
   }
 

--- a/app/services/log_entry_tag_service.ts
+++ b/app/services/log_entry_tag_service.ts
@@ -1,5 +1,6 @@
 import LogEntryTag from '#models/log_entry_tag'
 import LogEntry from '#models/log_entry'
+import { errors } from '@adonisjs/auth'
 
 export class LogEntryTagService {
   /*
@@ -39,16 +40,24 @@ export class LogEntryTagService {
     return logEntry.tags
   }
 
-  async updateTag(tagId: number, tagName: string) {
+  async updateTag(tagId: number, tagName: string, userId: string) {
     const tag = await LogEntryTag.findOrFail(tagId)
+
+    if (tag.userId !== userId) {
+      throw errors.E_UNAUTHORIZED_ACCESS
+    }
     tag.name = tagName
     await tag.save()
     return tag
   }
 
   // For security, we require the parent exploitation id to ensure the tag belongs to the correct exploitation
-  async deleteTag(tagId: number, parentExploitationId: string) {
+  async deleteTag(tagId: number, parentExploitationId: string, userId: string) {
     const tag = await LogEntryTag.findByOrFail({ id: tagId, exploitationId: parentExploitationId })
+
+    if (tag.userId !== userId) {
+      throw errors.E_UNAUTHORIZED_ACCESS
+    }
 
     await tag.delete()
     return tag

--- a/database/seeders/user_seeder.ts
+++ b/database/seeders/user_seeder.ts
@@ -14,6 +14,11 @@ export default class extends BaseSeeder {
         email: process.env.ADMIN_EMAIL,
         password: process.env.ADMIN_PASSWORD,
       },
+      {
+        fullName: 'Pierre Dupont',
+        email: 'beta@livingdata.co',
+        password: 'password',
+      },
     ])
   }
 }

--- a/inertia/components/exploitation-id/TagSelector.tsx
+++ b/inertia/components/exploitation-id/TagSelector.tsx
@@ -2,7 +2,7 @@ import { debounce } from 'lodash-es'
 import InputWithSelector from '~/ui/InputWithSelector'
 import { Button } from '@codegouvfr/react-dsfr/Button'
 import { router, usePage } from '@inertiajs/react'
-import { InferPageProps } from '@adonisjs/inertia/types'
+import { InferPageProps, SharedProps } from '@adonisjs/inertia/types'
 import ExploitationsController from '#controllers/exploitations_controller'
 import { LogEntryTagJson } from '../../../types/models'
 import { Tag } from '@codegouvfr/react-dsfr/Tag'
@@ -38,6 +38,7 @@ export function TagSelector({
     filteredLogEntryTags,
     existingLogEntryTags,
   } = usePage<InferPageProps<ExploitationsController, 'get'>>().props
+  const { user } = usePage<SharedProps>().props
 
   // To avoid redundant requests when switching log entries, we track the last requested log entry ID
   const lastLogEntryId = useRef<string>('')
@@ -71,28 +72,32 @@ export function TagSelector({
     value: t.id,
     label: t.name,
     isSelected: values.includes(t.id),
-    actions: [
-      {
-        value: t.id,
-        label: "Supprimer l'étiquette",
-        iconId: 'fr-icon-delete-bin-line',
-        isCritical: true,
-        onClick: (value: number) => {
-          router.delete(deleteTagForExploitationUrl, {
-            data: { tagId: value },
-            only: ['exploitation', 'filteredLogEntryTags'],
-            replace: true,
-            onSuccess: () => {
-              // If the deleted tag was selected, we remove it from the selection and from the cache
-              if (values.includes(value)) {
-                delete tagsCache[value]
-                onChange(values.filter((v) => v !== value))
-              }
+    actions:
+      // Only allow deletion of tags created by the current user
+      t.userId === user.id
+        ? [
+            {
+              value: t.id,
+              label: "Supprimer l'étiquette",
+              iconId: 'fr-icon-delete-bin-line',
+              isCritical: true,
+              onClick: (value: number) => {
+                router.delete(deleteTagForExploitationUrl, {
+                  data: { tagId: value },
+                  only: ['exploitation', 'filteredLogEntryTags'],
+                  replace: true,
+                  onSuccess: () => {
+                    // If the deleted tag was selected, we remove it from the selection and from the cache
+                    if (values.includes(value)) {
+                      delete tagsCache[value]
+                      onChange(values.filter((v) => v !== value))
+                    }
+                  },
+                })
+              },
             },
-          })
-        },
-      },
-    ],
+          ]
+        : undefined,
   }))
 
   // Retrieve selected tags from cache. Missing tags are undefined while waiting for fetching.

--- a/tests/unit/log_entry/log_entry_tag_service.spec.ts
+++ b/tests/unit/log_entry/log_entry_tag_service.spec.ts
@@ -45,7 +45,7 @@ test.group('Log entry tag service', (group) => {
       'Urgent'
     )
 
-    const updatedTag = await logEntryTagService.updateTag(tag.id, 'High Priority')
+    const updatedTag = await logEntryTagService.updateTag(tag.id, 'High Priority', user.id)
 
     assert.equal(updatedTag.name, 'High Priority')
   })
@@ -61,10 +61,29 @@ test.group('Log entry tag service', (group) => {
       'Urgent'
     )
 
-    await logEntryTagService.deleteTag(tag.id, exploitation.id)
+    await logEntryTagService.deleteTag(tag.id, exploitation.id, user.id)
 
     const tags = await logEntryTagService.getTagsForExploitation(exploitation.id)
 
     assert.lengthOf(tags, 0)
+  })
+
+  test("I cannot delete a log entry tag that doesn't belong to the current user", async ({
+    assert,
+  }) => {
+    const user1 = await UserFactory.create()
+    const user2 = await UserFactory.create()
+    const exploitation = await ExploitationFactory.create()
+    const logEntryTagService = new LogEntryTagService()
+
+    const tag = await logEntryTagService.createTagForExploitation(
+      exploitation.id,
+      user1.id,
+      'Urgent'
+    )
+
+    assert.rejects(async () => {
+      await logEntryTagService.deleteTag(tag.id, exploitation.id, user2.id)
+    })
   })
 })

--- a/types/models.ts
+++ b/types/models.ts
@@ -15,6 +15,10 @@ export type ExploitationTagJson = {
 export type LogEntryTagJson = {
   id: number
   name: string
+  userId: string
+  exploitationId: string
+  createdAt: string
+  updatedAt: string
 }
 
 export type LogEntryJson = {


### PR DESCRIPTION
Pour l'instant le bouton de menu contextuel est supprimé. Un meilleur retour utilisateur sera proposé après évolution prochaine des composants du sélecteur d'étiquette.

<img width="827" height="715" alt="image" src="https://github.com/user-attachments/assets/2bc7f446-75a6-4dc1-a8b7-6fa48ccfaa70" />
