### PR TITLE
Autoriser les boutons disabled dans le menu des actions

### DIFF
--- a/inertia/ui/MoreButton/index.tsx
+++ b/inertia/ui/MoreButton/index.tsx
@@ -6,9 +6,10 @@ import { Button } from '@codegouvfr/react-dsfr/Button'
 
 export type MoreButtonProps = {
   actions: {
-    label: string
+    label: string | React.ReactNode
     iconId?: string
     isCritical?: boolean
+    isDisabled?: boolean
     onClick: () => void
   }[]
 }
@@ -118,10 +119,11 @@ export default function MoreButton({ actions }: MoreButtonProps) {
               }}
             >
               <ul className="fr-px-2v w-fit flex flex-col gap-2" role="menu">
-                {actions.map((action) => (
-                  <li
-                    key={action.label}
-                    className="list-none w-fit flex items-center gap-2 cursor-pointer"
+                {actions.map((action, index) => (
+                  <button
+                    key={`label-${index}`}
+                    disabled={action.isDisabled}
+                    className="fr-p-1v list-none w-full flex items-center gap-2 cursor-pointer"
                     style={{
                       color: `${action.isCritical ? fr.colors.decisions.text.default.error.default : ''}`,
                     }}
@@ -137,12 +139,13 @@ export default function MoreButton({ actions }: MoreButtonProps) {
                         setMenuOpen(false)
                       }
                     }}
+                    type="button"
                     role="menuitem"
                     tabIndex={0}
                   >
                     {action.iconId && <span className={`${action.iconId} fr-icon--sm`} />}
                     {action.label}
-                  </li>
+                  </button>
                 ))}
               </ul>
             </div>,

--- a/inertia/ui/MoreButton/more-button.stories.tsx
+++ b/inertia/ui/MoreButton/more-button.stories.tsx
@@ -1,4 +1,5 @@
 import MoreButton, { MoreButtonProps } from './index.js'
+import { Tooltip } from '@codegouvfr/react-dsfr/Tooltip'
 
 const meta = {
   title: 'UI/MoreButton',
@@ -17,6 +18,12 @@ const meta = {
         label: 'Modifier',
         iconId: 'fr-icon-edit-line',
         onClick: () => alert('Modifier action clicked'),
+      },
+      {
+        label: <Tooltip title="Impossible de dupliquer cet élément">Dupliquer</Tooltip>,
+        iconId: 'fr-icon-stack-line',
+        isDisabled: true,
+        onClick: () => alert('Dupliquer action clicked'),
       },
       {
         label: 'Supprimer',


### PR DESCRIPTION
Cette pull request met à jour le composant d’interface `MoreButton `afin d’améliorer l’accessibilité et la flexibilité des éléments d’action. Les changements les plus importants sont le passage de `<li>` à `<button>` pour les actions du menu, la prise en charge des états désactivés, ainsi que la possibilité d’utiliser des libellés plus riches, tels que des info-bulles.
<img width="1088" height="332" alt="Capture d’écran 2025-12-04 à 16 27 33" src="https://github.com/user-attachments/assets/d3eab2d1-7e41-4e93-bca2-4c7d97a70c39" />