### PR TITLE
Conserve l'ouverture du menu lorsqu'on clique en dehors

### DIFF
--- a/inertia/ui/ButtonWithSelector/index.tsx
+++ b/inertia/ui/ButtonWithSelector/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState } from 'react'
 
 import SelectorMenu from '../SelectorMenu'
 import Button from '@codegouvfr/react-dsfr/Button'
@@ -25,10 +25,9 @@ export default function ButtonWithSelector<T extends string | number>({
   onOptionChange,
 }: ButtonWithSelectorProps<T>) {
   const [dropdownOpen, setDropdownOpen] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
 
   return (
-    <div style={{ position: 'relative', width: 'fit-content' }} ref={containerRef}>
+    <div style={{ position: 'relative', width: 'fit-content' }}>
       <Button className="fr-m-0" onClick={() => setDropdownOpen(!dropdownOpen)} priority={priority}>
         {label}
       </Button>


### PR DESCRIPTION
Cette PR modifie le composant `ButtonWithSelector` en supprimant la logique qui fermait le menu déroulant lorsqu’on cliquait en dehors de celui-ci.


<img width="1123" height="725" alt="Capture d’écran 2025-12-05 à 15 14 02" src="https://github.com/user-attachments/assets/51dfe204-48bf-4c84-9754-a78196b7ad27" />
