### PR TITLE
Gestion des pictos de cultures suivant la couleur de fond

### DIFF
--- a/inertia/components/cultures-legend.tsx
+++ b/inertia/components/cultures-legend.tsx
@@ -1,5 +1,5 @@
 import { values } from 'lodash-es'
-import { GROUPES_CULTURAUX } from '~/functions/cultures-group'
+import { GROUPES_CULTURAUX, getContrastedPicto } from '~/functions/cultures-group'
 
 export default function CulturesLegend() {
   const culturesItems = values(GROUPES_CULTURAUX)
@@ -9,7 +9,7 @@ export default function CulturesLegend() {
       {culturesItems.map((culture) => (
         <div key={culture.code_group} className="flex items-center gap-2">
           <div className="w-3 h-3 rounded-full" style={{ backgroundColor: culture.color }} />
-          <img src={culture.picto_light} alt={culture.label} className="w-4 h-4 mr-2" />
+          <img src={getContrastedPicto(culture)} alt={culture.label} className="w-4 h-4 mr-2" />
           <span className="text-sm">{culture.label}</span>
         </div>
       ))}

--- a/inertia/functions/cultures-group.tsx
+++ b/inertia/functions/cultures-group.tsx
@@ -1,6 +1,8 @@
 import { has } from 'lodash-es'
 import tinycolor from 'tinycolor2'
 
+import { useIsLightTheme } from '~/hooks/use-is-light'
+
 export type GroupeCulturauxItem = {
   label: string
   code_group: number | string
@@ -217,10 +219,9 @@ export function getCulturesGroup(code: string | number) {
 
 export function getContrastedPicto(
   culture: { picto_light: string; picto_dark: string },
-  background: string
+  background?: string
 ): string {
-  const color = tinycolor(background)
-  const isLight = color.isLight()
+  const isLight = background ? tinycolor(background).isLight() : useIsLightTheme()
 
   return isLight ? culture.picto_light : culture.picto_dark
 }

--- a/inertia/hooks/use-is-light.tsx
+++ b/inertia/hooks/use-is-light.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+import tinycolor from 'tinycolor2'
+
+export function useIsLightTheme(): boolean {
+  const [isLight, setIsLight] = useState(true)
+
+  useEffect(() => {
+    const backgroundColor = window.getComputedStyle(document.body).backgroundColor
+    const color = tinycolor(backgroundColor)
+    setIsLight(color.isLight())
+  }, [])
+
+  return isLight
+}


### PR DESCRIPTION
Amélioration du contraste des pictogrammes dans CulturesLegend : sélection automatique du picto clair ou sombre selon la couleur de fond ou le thème.

Principaux changements :
* `getContrastedPicto` utilise désormais la couleur de fond du thème lorsqu’aucun fond n’est fourni, afin de choisir automatiquement la variante de pictogramme la plus lisible.
* `CulturesLegend` s’appuie sur `getContrastedPicto` pour adapter chaque picto au thème ou au fond.
* Nouveau hook `useIsLightTheme` pour détecter si le thème actuel est clair ou sombre en analysant la couleur de fond du body.

### **Clair**
<img width="867" height="775" alt="Capture d’écran 2025-12-12 à 15 44 01" src="https://github.com/user-attachments/assets/cdf4d7f1-5cba-412f-9696-3a7aab9c87a8" />

### **Sombre**
<img width="633" height="767" alt="Capture d’écran 2025-12-12 à 15 44 16" src="https://github.com/user-attachments/assets/9ddebbf0-e52d-48b4-879b-9f5373106ebe" />
