### PR TITLE
Corriger le fallback pour désigner le groupe de culture

### DIFF
--- a/inertia/functions/cultures-group.tsx
+++ b/inertia/functions/cultures-group.tsx
@@ -212,7 +212,7 @@ export const GROUPES_CULTURAUX: { [key: string]: GroupeCulturauxItem } = {
 
 export function getCulturesGroup(code: string | number) {
   if (!has(GROUPES_CULTURAUX, code)) {
-    return GROUPES_CULTURAUX[18]
+    return GROUPES_CULTURAUX[28]
   }
   return GROUPES_CULTURAUX[code]
 }


### PR DESCRIPTION
Ajustement mineur de getCulturesGroup : changement du groupe par défaut utilisé en cas de code introuvable (`GROUPES_CULTURAUX[18]` → `GROUPES_CULTURAUX[28]`).