### PR TITLE
Correction de l'affichage du placeholder du journal de bord

### DIFF
--- a/inertia/components/exploitation-id/ExploitationLog.tsx
+++ b/inertia/components/exploitation-id/ExploitationLog.tsx
@@ -53,7 +53,7 @@ export function ExploitationLog({
     })
   }
 
-  if (!logEntries) {
+  if (logEntries?.length === 0) {
     return (
       <EmptyPlaceholder
         illustrativeIcon="fr-icon-booklet-line"


### PR DESCRIPTION
Le placeholder quand il n'y avait pas encore d'entrée de journal de bord ne s'affichait plus, c'est maintenant corrigé.

<img width="1239" height="949" alt="image" src="https://github.com/user-attachments/assets/e2eb7eb9-8828-4b5d-8fab-62f6207fd6bc" />
