### PR TITLE
Ajout d'une github action : Vérification du package-lock.json

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -49,9 +49,6 @@ jobs:
       - name: Verify package-lock.json is up to date
         run: |
           npm install --package-lock-only --ignore-scripts
-      - name: Verify package-lock.json is up to date
-        run: |
-          npm install --package-lock-only --ignore-scripts
           git diff --exit-code package-lock.json || {
             echo "❌ package-lock.json and package.json are out of sync!"
             echo "ℹ️ Run 'npm install' and commit the updated package-lock.json"


### PR DESCRIPTION
Cette PR ajoute une action Github qui vérifie que les fichiers package.json et package-lock.json sont bien synchronisés.

