### PR TITLE
Enregistrement des évènements utilisateurs

### DIFF
--- a/app/controllers/accueil_controller.ts
+++ b/app/controllers/accueil_controller.ts
@@ -4,6 +4,11 @@ import { ExploitationService } from '#services/exploitation_service'
 import { LogEntryService } from '#services/log_entry_service'
 import { EventLoggerService } from '#services/event_logger_service'
 
+// Définition centralisée des noms d'événements pour ce contrôleur
+const EVENTS = {
+  PAGE_VIEW: { name: 'accueil_page_viewed' },
+}
+
 @inject()
 export default class AccueilController {
   constructor(
@@ -14,7 +19,7 @@ export default class AccueilController {
   async index({ inertia, auth }: HttpContext) {
     const user = auth.getUserOrFail()
 
-    this.eventLogger.logEvent({ userId: user.id, name: 'accueil_page_viewed' })
+    this.eventLogger.logEvent({ userId: user.id, ...EVENTS.PAGE_VIEW })
 
     const latestExploitations = await this.exploitationService.queryLatestExploitations()
     const latestLogEntries = await this.logEntryService.getLatestLogEntriesFromUser(user.id)

--- a/app/controllers/exploitations_controller.ts
+++ b/app/controllers/exploitations_controller.ts
@@ -14,6 +14,20 @@ import { LogEntryService } from '#services/log_entry_service'
 import { LogEntryDto } from '../dto/log_entry_dto.js'
 import { EventLoggerService } from '#services/event_logger_service'
 
+// Définition centralisée des noms d'événements pour ce contrôleur
+const EVENTS = {
+  INDEX_VIEW: { name: 'exploitations_index', step: 'viewed' },
+  CREATE_FORM: { name: 'exploitations_create', step: 'form_viewed' },
+  UPDATE_FORM: { name: 'exploitations_update', step: 'form_viewed' },
+  PAGE_VIEW: { name: 'exploitation_page_viewed' },
+  CREATE_SEARCHED_BY_SIRET: { name: 'exploitations_create', step: 'searched_by_siret' },
+  CREATE_SUBMITTED: { name: 'exploitations_create', step: 'submitted' },
+  CREATE_CREATED: { name: 'exploitations_create', step: 'created' },
+  UPDATE_SUBMITTED: { name: 'exploitations_update', step: 'submitted' },
+  UPDATE_UPDATED: { name: 'exploitations_update', step: 'updated' },
+  DELETED: { name: 'exploitations_deleted' },
+}
+
 @inject()
 export default class ExploitationsController {
   constructor(
@@ -27,8 +41,7 @@ export default class ExploitationsController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitations_index',
-      step: 'viewed',
+      ...EVENTS.INDEX_VIEW,
       context: {
         searchQuery: request.input('recherche') || null,
         page: request.input('page', 1),
@@ -62,8 +75,7 @@ export default class ExploitationsController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitations_create',
-      step: 'form_viewed',
+      ...EVENTS.CREATE_FORM,
     })
 
     return inertia.render('exploitations/creation')
@@ -73,8 +85,7 @@ export default class ExploitationsController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitations_update',
-      step: 'form_viewed',
+      ...EVENTS.UPDATE_FORM,
       context: { exploitationId: params.id },
     })
 
@@ -97,7 +108,7 @@ export default class ExploitationsController {
 
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitation_page_viewed',
+      ...EVENTS.PAGE_VIEW,
       context: { exploitationId: params.id, logPage: page },
     })
 
@@ -159,8 +170,7 @@ export default class ExploitationsController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitations_create',
-      step: 'searched_by_siret',
+      ...EVENTS.CREATE_SEARCHED_BY_SIRET,
       context: { siret: params.siret },
     })
 
@@ -176,8 +186,7 @@ export default class ExploitationsController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitations_create',
-      step: 'submitted',
+      ...EVENTS.CREATE_SUBMITTED,
       context: { payload: request.all() },
     })
 
@@ -210,8 +219,7 @@ export default class ExploitationsController {
 
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitations_create',
-      step: 'created',
+      ...EVENTS.CREATE_CREATED,
     })
 
     createSuccessFlashMessage(session, `L'exploitation ${payload.name} a été créée.`)
@@ -223,8 +231,7 @@ export default class ExploitationsController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitations_update',
-      step: 'submitted',
+      ...EVENTS.UPDATE_SUBMITTED,
     })
 
     const {
@@ -258,8 +265,7 @@ export default class ExploitationsController {
 
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitations_update',
-      step: 'updated',
+      ...EVENTS.UPDATE_UPDATED,
     })
 
     createSuccessFlashMessage(session, `L'exploitation ${payload.name} a été modifiée.`)
@@ -271,7 +277,7 @@ export default class ExploitationsController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'exploitations_deleted',
+      ...EVENTS.DELETED,
       context: { exploitationId: params.id },
     })
 

--- a/app/controllers/log_entries_controller.ts
+++ b/app/controllers/log_entries_controller.ts
@@ -12,6 +12,18 @@ import { createLogEntryTagValidator, deleteLogEntryTagValidator } from '#validat
 import { errors } from '@adonisjs/auth'
 import { EventLoggerService } from '#services/event_logger_service'
 
+// Définition centralisée des noms d'événements pour ce contrôleur
+const EVENTS = {
+  CREATE_SUBMITTED: { name: 'log_entries_create', step: 'submitted' },
+  CREATE_CREATED: { name: 'log_entries_create', step: 'created' },
+  UPDATE_SUBMITTED: { name: 'log_entries_update', step: 'submitted' },
+  UPDATE_UPDATED: { name: 'log_entries_update', step: 'updated' },
+  DELETED: { name: 'log_entries_deleted' },
+  TAG_CREATE_SUBMITTED: { name: 'log_entry_tags_create', step: 'submitted' },
+  TAG_CREATE_CREATED: { name: 'log_entry_tags_create', step: 'created' },
+  TAG_DELETED: { name: 'log_entry_tags_deleted' },
+}
+
 @inject()
 export default class LogEntriesController {
   constructor(
@@ -24,8 +36,7 @@ export default class LogEntriesController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'log_entries_create',
-      step: 'submitted',
+      ...EVENTS.CREATE_SUBMITTED,
       context: { payload: request.all() },
     })
 
@@ -41,8 +52,7 @@ export default class LogEntriesController {
 
       this.eventLogger.logEvent({
         userId: user.id,
-        name: 'log_entries_create',
-        step: 'created',
+        ...EVENTS.CREATE_CREATED,
       })
 
       createSuccessFlashMessage(session, "L'entrée de journal a été créée avec succès.")
@@ -61,8 +71,7 @@ export default class LogEntriesController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'log_entries_update',
-      step: 'submitted',
+      ...EVENTS.UPDATE_SUBMITTED,
       context: { payload: request.all() },
     })
     const { id, params, ...payload } = await request.validateUsing(updateLogEntryValidator)
@@ -75,8 +84,7 @@ export default class LogEntriesController {
 
       this.eventLogger.logEvent({
         userId: user.id,
-        name: 'log_entries_update',
-        step: 'updated',
+        ...EVENTS.UPDATE_UPDATED,
       })
 
       createSuccessFlashMessage(session, "L'entrée de journal a été mise à jour avec succès.")
@@ -99,7 +107,7 @@ export default class LogEntriesController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'log_entries_deleted',
+      ...EVENTS.DELETED,
       context: { payload: request.all() },
     })
     const { id, params } = await request.validateUsing(destroyLogEntryValidator)
@@ -126,8 +134,7 @@ export default class LogEntriesController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'log_entry_tag_create',
-      step: 'submitted',
+      ...EVENTS.TAG_CREATE_SUBMITTED,
       context: { payload: request.all() },
     })
     const payload = await request.validateUsing(createLogEntryTagValidator)
@@ -141,8 +148,7 @@ export default class LogEntriesController {
 
       this.eventLogger.logEvent({
         userId: user.id,
-        name: 'log_entry_tag_create',
-        step: 'created',
+        ...EVENTS.TAG_CREATE_CREATED,
       })
     } catch (error) {
       logger.error('Error creating tag for exploitation:', error)
@@ -158,7 +164,7 @@ export default class LogEntriesController {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'log_entry_tag_deleted',
+      ...EVENTS.TAG_DELETED,
     })
     const payload = await request.validateUsing(deleteLogEntryTagValidator)
 

--- a/app/controllers/session_controller.ts
+++ b/app/controllers/session_controller.ts
@@ -6,6 +6,12 @@ import { inject } from '@adonisjs/core'
 
 const redirectAfterLogin = '/accueil'
 
+// Définition centralisée des noms d'événements pour ce contrôleur
+const EVENTS = {
+  LOG_BACK: { name: 'session_log_back' },
+  LOGIN: { name: 'session_login' },
+}
+
 @inject()
 export default class SessionController {
   constructor(public eventLogger: EventLoggerService) {}
@@ -15,7 +21,7 @@ export default class SessionController {
     try {
       const user = await auth.use('web').authenticate()
 
-      this.eventLogger.logEvent({ userId: user.id, name: 'session_log_back' })
+      this.eventLogger.logEvent({ userId: user.id, ...EVENTS.LOG_BACK })
 
       return response.redirect(redirectAfterLogin)
     } catch (error) {
@@ -33,7 +39,7 @@ export default class SessionController {
     const { email, password } = request.only(['email', 'password'])
 
     const user = await User.verifyCredentials(email.toLowerCase(), password)
-    this.eventLogger.logEvent({ userId: user.id, name: 'session_login' })
+    this.eventLogger.logEvent({ userId: user.id, ...EVENTS.LOGIN })
     await auth.use('web').login(user, !!request.input('remember_me'))
 
     response.redirect(redirectAfterLogin)

--- a/app/controllers/visualisation_controller.ts
+++ b/app/controllers/visualisation_controller.ts
@@ -5,6 +5,11 @@ import { ExploitationService } from '#services/exploitation_service'
 import env from '#start/env'
 import { EventLoggerService } from '#services/event_logger_service'
 
+// Définition centralisée des noms d'événements pour ce contrôleur
+const EVENTS = {
+  PAGE_VIEW: { name: 'visualisation_page_viewed' },
+}
+
 @inject()
 export default class VisualisationController {
   constructor(
@@ -17,7 +22,7 @@ export default class VisualisationController {
 
     this.eventLogger.logEvent({
       userId: user.id,
-      name: 'visualisation_page_viewed',
+      ...EVENTS.PAGE_VIEW,
       context: request.all(),
     })
 

--- a/app/models/event_log.ts
+++ b/app/models/event_log.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, hasOne } from '@adonisjs/lucid/orm'
-import type { HasOne } from '@adonisjs/lucid/types/relations'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import User from '#models/user'
 
 /*
@@ -28,8 +28,8 @@ export default class EventLog extends BaseModel {
   /*
     The ID of the user who performed the event. Null if the user is not logged in.
    */
-  @hasOne(() => User)
-  declare user: HasOne<typeof User> | null
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User> | null
 
   @column()
   declare userId: string | null

--- a/app/services/event_logger_service.ts
+++ b/app/services/event_logger_service.ts
@@ -1,7 +1,17 @@
 import EventLog from '#models/event_log'
 
-// Service to log significant events in the system for auditing purposes. Will never throw errors.
+// Service to log significant events in the system for auditing purposes.
 export class EventLoggerService {
+  /**
+   * Logs an event asynchronously. Will never throw errors.
+   *
+   * @param event Object containing event details.
+   * @param event.name Name of the event. Should contain the action performed, e.g., 'user_login'.
+   * @param event.step Optional step or phase of the event. E.g., 'started', 'completed'.
+   * @param event.userId Optional ID of the user associated with the event.
+   * @param event.context Optional additional context for the event.
+   * @param event.version Optional version number of the event schema. Defaults to 1.
+   */
   public logEvent(event: {
     name: string
     step?: string | null

--- a/database/migrations/1767802748028_create_event_logs_table.ts
+++ b/database/migrations/1767802748028_create_event_logs_table.ts
@@ -15,6 +15,10 @@ export default class extends BaseSchema {
       table.integer('version').defaultTo(1)
 
       table.timestamp('created_at')
+
+      table.index(['created_at'])
+      table.index(['user_id', 'created_at'])
+      table.index(['name', 'created_at'])
     })
   }
 


### PR DESCRIPTION
Dans cette PR, nous enregistrons les évènements initiés par les utilisateurs à des fins d'observabilité et de contrôle qualité. Ce traçage se fait de façon non-intrusive, sans collecte de données supplémentaires.

Techniquement, on utilise la fonction native queueMicrotask() pour lancer des taches en mode "fire and forget" pour s'assurer qu'un échec d'enregistrement d'évènement ne puisse jamais interrompre la logique métier de l'application.

Closes #137 