### PR TITLE
Changement de méthode de seeding des utilisateurs pour le test du MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,4 @@ DB_DATABASE=vizeau
 ADMIN_EMAIL=dev@livingdata.co
 ADMIN_PASSWORD=secret
 PMTILES_URL=
+USERS_TO_SEED='[{"fullName":"Pierre Dupont","email":"beta@livingdata.co","password":"password"}]'

--- a/database/seeders/1_user_seeder.ts
+++ b/database/seeders/1_user_seeder.ts
@@ -1,24 +1,19 @@
 import { BaseSeeder } from '@adonisjs/lucid/seeders'
 import User from '#models/user'
+import Env from '#start/env'
 
 export default class extends BaseSeeder {
   async run() {
-    if (!process.env.ADMIN_EMAIL || !process.env.ADMIN_PASSWORD) {
-      console.error('Admin e-mail address or password is not defined in the environment variables.')
-      process.exit(1)
-    }
-
-    await User.updateOrCreateMany('email', [
-      {
-        fullName: 'Jeanne Martin',
-        email: process.env.ADMIN_EMAIL,
-        password: process.env.ADMIN_PASSWORD,
-      },
-      {
-        fullName: 'Pierre Dupont',
-        email: 'beta@livingdata.co',
-        password: 'password',
-      },
-    ])
+    const usersToInject = JSON.parse(Env.get('USERS_TO_SEED') || '[]')
+    await User.updateOrCreateMany(
+      'email',
+      [
+        {
+          fullName: 'Jeanne Martin',
+          email: process.env.ADMIN_EMAIL,
+          password: process.env.ADMIN_PASSWORD,
+        },
+      ].concat(usersToInject)
+    )
   }
 }

--- a/start/env.ts
+++ b/start/env.ts
@@ -51,4 +51,7 @@ export default await Env.create(new URL('../', import.meta.url), {
    */
   // If set, enables the integration with the PMTiles server for map tile hosting
   PMTILES_URL: Env.schema.string.optional({ format: 'url' }),
+
+  // If set, the string will be parsed as JSON and the content will be injected as users
+  USERS_TO_SEED: Env.schema.string.optional(),
 })


### PR DESCRIPTION
Cette PR propose une méthode de seeding différente pour générer des utilisateurs. Quand on lance le seeding avec `ace db:seed`, la variable d'environnement USERS_TO_SEED est lue en tant que tableau JSON (JSON.parse). 

Cette méthode permet d'injecter un grand nombre d'utilisateurs en une fois sans stocker leurs adresses e-mail dans Git ni de dépendre d'un service tiers tel qu'un vault ou un bucket S3. 