### PR TITLE
On peut déselectionner une exploitation sur la carte

### DIFF
--- a/inertia/components/map-layer-filters.tsx
+++ b/inertia/components/map-layer-filters.tsx
@@ -43,7 +43,7 @@ export default function MapLayerFilters({
               name: 'parcelles',
               value: 'parcelles',
               checked: showParcelles,
-              onChange: () => setShowParcelles((prev) => !prev)
+              onChange: () => setShowParcelles((prev) => !prev),
             },
           },
         ]}
@@ -57,14 +57,14 @@ export default function MapLayerFilters({
             label: (
               <span className="fr-text--sm fr-mb-0 flex items-center gap-1">
                 AAC
-                <Tooltip kind="hover" title="Aire d’Alimentation de Captage" />
+                <Tooltip kind="hover" title="Aire d'alimentation de captage" />
               </span>
             ),
             nativeInputProps: {
               name: 'aac',
               value: 'aac',
               checked: showAac,
-              onChange: () => setShowAac((prev) => !prev)
+              onChange: () => setShowAac((prev) => !prev),
             },
           },
         ]}
@@ -76,14 +76,14 @@ export default function MapLayerFilters({
           {
             label: (
               <span className="fr-text--sm fr-mb-0 flex items-center gap-1">
-                PPE <Tooltip kind="hover" title="Périmètre de Protection des Eaux" />
+                PPE <Tooltip kind="hover" title="Périmètre de protection éloignée" />
               </span>
             ),
             nativeInputProps: {
               name: 'ppe',
               value: 'ppe',
               checked: showPpe,
-              onChange: () => setShowPpe((prev) => !prev)
+              onChange: () => setShowPpe((prev) => !prev),
             },
           },
         ]}
@@ -96,14 +96,14 @@ export default function MapLayerFilters({
           {
             label: (
               <span className="fr-text--sm fr-mb-0 flex items-center gap-1">
-                PPR <Tooltip kind="hover" title="Plan de Prévention des Risques" />
+                PPR <Tooltip kind="hover" title="Périmètre de protection rapprochée" />
               </span>
             ),
             nativeInputProps: {
               name: 'ppr',
               value: 'ppr',
               checked: showPpr,
-              onChange: () => setShowPpr((prev) => !prev)
+              onChange: () => setShowPpr((prev) => !prev),
             },
           },
         ]}
@@ -123,7 +123,7 @@ export default function MapLayerFilters({
               name: 'communes',
               value: 'communes',
               checked: showCommunes,
-              onChange: () => setShowCommunes((prev) => !prev)
+              onChange: () => setShowCommunes((prev) => !prev),
             },
           },
         ]}

--- a/inertia/components/visualisation-left-side-bar.tsx
+++ b/inertia/components/visualisation-left-side-bar.tsx
@@ -15,13 +15,15 @@ export default function VisualisationLeftSideBar({
   selectedExploitation,
   setSelectedExploitationId,
   isMapLoading,
+  editMode,
 }: {
   exploitations: ExploitationJson[]
   queryString?: { recherche?: string }
   handleSearch: (e: ChangeEvent<HTMLInputElement>) => void
   selectedExploitation?: ExploitationJson
-  setSelectedExploitationId: (exploitationId: string) => void
+  setSelectedExploitationId: (exploitationId: string | undefined) => void
   isMapLoading: boolean
+  editMode: boolean
 }) {
   return (
     <div>
@@ -30,7 +32,24 @@ export default function VisualisationLeftSideBar({
           <Breadcrumb
             currentPageLabel={selectedExploitation?.name}
             segments={[
-              { label: 'Liste des exploitations agricoles', linkProps: { href: '/visualisation' } },
+              {
+                label: 'Liste des exploitations agricoles',
+                linkProps: {
+                  href: '#',
+                  onClick: () => {
+                    // Only allow going back to the list if not in edit mode
+                    if (!editMode) {
+                      setSelectedExploitationId(undefined)
+                    }
+                  },
+                  style: {
+                    cursor: !editMode ? 'pointer' : 'not-allowed',
+                    // href "#" transforms the link into a button with blue text, we override it to look like a normal link
+                    fontSize: 'inherit',
+                    color: 'inherit',
+                  },
+                },
+              },
             ]}
             style={{ marginBottom: fr.spacing('2v') }}
             className="fr-m-1w"

--- a/inertia/pages/visualisation.tsx
+++ b/inertia/pages/visualisation.tsx
@@ -165,6 +165,7 @@ export default function VisualisationPage({
             selectedExploitation={selectedExploitation}
             setSelectedExploitationId={setSelectedExploitationId}
             isMapLoading={isMapLoading}
+            editMode={editMode}
           />
         }
         headerAdditionalContent={


### PR DESCRIPTION
Cette PR permet de déselectionner une exploitation pour revenir à la liste des exploitations sans recharger la page complète.

https://github.com/user-attachments/assets/5fb1b9ce-457e-4cc0-957e-23b87ab93d45

Elle corrige également quelques tooltips dans la légende.