### PR TITLE
Corrige l'export des exploitations en CSV

### DIFF
--- a/inertia/lib/export_csv.ts
+++ b/inertia/lib/export_csv.ts
@@ -1,10 +1,36 @@
-export function downloadCsv<T extends Record<string, any>>(data: T[] = [], filename = 'data.csv') {
+export function exportExploitationsAsCSV<T extends Record<string, any>>(
+  data: T[] = [],
+  filename = 'data.csv'
+) {
   if (data.length === 0) return
 
-  const headers = Object.keys(data[0])
+  // Transformation des données
+  const transformedData = data.map((row) => {
+    const { id, location, contacts, ...rest } = row
+
+    // Trouver le contact principal
+    const primaryContact = Array.isArray(contacts)
+      ? contacts.find((c: any) => c.isPrimaryContact) || contacts[0]
+      : null
+
+    return {
+      ...rest,
+      longitude: location?.x ?? '',
+      latitude: location?.y ?? '',
+      contact_prenom: primaryContact?.firstName ?? '',
+      contact_nom: primaryContact?.lastName ?? '',
+      contact_email: primaryContact?.email ?? '',
+      contact_telephone: primaryContact?.phoneNumber ?? '',
+      contact_role: primaryContact?.role ?? '',
+    }
+  })
+
+  const headers = Object.keys(transformedData[0])
   const csvContent = [
     headers.join(','),
-    ...data.map((row) => headers.map((header) => JSON.stringify(row[header] ?? '')).join(',')),
+    ...transformedData.map((row) =>
+      headers.map((header) => JSON.stringify(row[header] ?? '')).join(',')
+    ),
   ].join('\n')
 
   const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })

--- a/inertia/pages/exploitations/index.tsx
+++ b/inertia/pages/exploitations/index.tsx
@@ -7,7 +7,7 @@ import { SearchBar } from '@codegouvfr/react-dsfr/SearchBar'
 import { Pagination } from '@codegouvfr/react-dsfr/Pagination'
 
 import Layout from '~/ui/layouts/layout'
-import { downloadCsv } from '~/lib/export_csv'
+import { exportExploitationsAsCSV } from '~/lib/export_csv'
 import ExploitationsList from '~/components/exploitations/exploitations-list'
 import ExploitationsTable from '~/components/exploitations/exploitations-table'
 import { debounce } from 'lodash-es'
@@ -77,7 +77,9 @@ export default function Exploitations({
                   priority="secondary"
                   iconId="fr-icon-download-line"
                   title="Télécharger"
-                  onClick={() => downloadCsv(exploitations, 'exploitations-export.csv')}
+                  onClick={() =>
+                    exportExploitationsAsCSV(exploitations, 'exploitations-export.csv')
+                  }
                 />
                 {!isList && (
                   <ButtonWithSelector


### PR DESCRIPTION
Cette PR modifie l'export en CSV de la liste des exploitations.

Le nom de la fonction a été renommé pour être plus clair.

Fix #187 
