### PR TITLE
Ajout d'une hauteur max sur SelectorMenu

### DIFF
--- a/inertia/ui/SelectorMenu/index.tsx
+++ b/inertia/ui/SelectorMenu/index.tsx
@@ -35,6 +35,8 @@ export default function SelectorMenu<T extends string | number>({
         background: fr.colors.decisions.background.default.grey.default,
         overflowY: 'auto',
         width: '100%',
+        maxHeight: '190px',
+        overflowX: 'hidden'
       }}
     >
       {groupNames &&


### PR DESCRIPTION
Ajout d'une hauteur max sur `SelectorMenu` afin d'éviter une hauteur trop haute sur les grandes listes