### PR TITLE
Ajout d'une limite à TagsList

### DIFF
--- a/inertia/ui/CustomTag/index.tsx
+++ b/inertia/ui/CustomTag/index.tsx
@@ -22,7 +22,7 @@ export default function CustomTag({ label, iconId, iconPath, size, color }: Cust
 
   return (
     <Badge
-      className={`height-fit w-fit flex gap-1 fr-mb-0 items-center`}
+      className={`height-fit w-fit flex gap-1 fr-m-0 items-center`}
       style={{ backgroundColor, color: textColor }}
       small={size === 'sm'}
     >

--- a/inertia/ui/ListItem/index.tsx
+++ b/inertia/ui/ListItem/index.tsx
@@ -127,7 +127,7 @@ export default function ListItem({
                   )}
                   <div className="flex-1 fr-m-0 fr-text--md font-bold">{title}</div>
                 </div>
-                {tags && tags.length > 0 && <TagsList tags={tags} size="sm" />}
+                {tags && tags.length > 0 && <TagsList tags={tags} limit={5} size="sm" />}
               </div>
 
               {actions && actions.length > 0 && <MoreButton actions={actions} />}
@@ -163,7 +163,7 @@ export default function ListItem({
           />
         )}
         <div>
-          {tags && tags.length > 0 && <TagsList tags={tags} size="sm" />}
+          {tags && tags.length > 0 && <TagsList tags={tags} size="sm" limit={5} />}
 
           <div className="flex items-start">
             <div className="flex flex-1 flex-col">

--- a/inertia/ui/TagsList/index.tsx
+++ b/inertia/ui/TagsList/index.tsx
@@ -7,17 +7,21 @@ export type TagsListProps = {
     iconId?: string
   }[]
   size?: 'md' | 'sm'
+  limit?: number
 }
-export default function TagsList({ tags, size = 'md' }: TagsListProps) {
+export default function TagsList({ tags, size = 'md', limit }: TagsListProps) {
   const uniqueMetas = uniqBy(tags, 'label')
 
   return (
-    <ul className="fr-badges-group">
-      {uniqueMetas.map(({ label, iconId }) => (
-        <li key={label} className="fr-mb-0">
+    <ul className="fr-badges-group gap-2 flex flex-wrap fr-mb-0 items-center">
+      {uniqueMetas.slice(0, limit).map(({ label, iconId }) => (
+        <li key={label} className="fr-mb-0 h-fit">
           <CustomTag label={label} iconId={iconId} size={size} />
         </li>
       ))}
+      {limit && tags.length > limit && (
+        <li className="fr-mb-0 font-thin italic">+{tags.length - limit}</li>
+      )}
     </ul>
   )
 }


### PR DESCRIPTION
Ajout d'une limite optionnelle à `TagsList` afin d'éviter un empilement des tags
<img width="1762" height="406" alt="Capture d’écran 2026-01-27 à 11 59 32" src="https://github.com/user-attachments/assets/5c7c8b40-8882-48b6-9ae9-c7ccb73c1912" />
