### PR TITLE
Ajout d'une Tooltip dans TagsList

### DIFF
--- a/inertia/ui/TagsList/index.tsx
+++ b/inertia/ui/TagsList/index.tsx
@@ -1,5 +1,6 @@
 import uniqBy from 'lodash-es/uniqBy'
 import CustomTag from '../CustomTag'
+import Tooltip from '@codegouvfr/react-dsfr/Tooltip'
 
 export type TagsListProps = {
   tags: {
@@ -20,7 +21,16 @@ export default function TagsList({ tags, size = 'md', limit }: TagsListProps) {
         </li>
       ))}
       {limit && tags.length > limit && (
-        <li className="fr-mb-0 font-thin italic">+{tags.length - limit}</li>
+        <li className="fr-mb-0 font-thin italic cursor-default">
+          <Tooltip
+            title={`${tags
+              .slice(limit, tags.length)
+              .map((tag) => tag.label)
+              .join(' - ')}`}
+          >
+            +{tags.length - limit}
+          </Tooltip>
+        </li>
       )}
     </ul>
   )

--- a/inertia/ui/TagsList/tags-list.stories.tsx
+++ b/inertia/ui/TagsList/tags-list.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
   argTypes: {
     tags: { control: 'object' },
     size: { control: 'radio', options: ['sm', 'md'] },
+    limit: { control: 'number' },
   },
   args: {
     tags: [
@@ -16,6 +17,7 @@ const meta = {
       { label: 'Information', iconId: 'fr-icon-information-line' },
     ],
     size: 'md',
+    limit: undefined,
   } as TagsListProps,
 }
 
@@ -26,5 +28,23 @@ export const Défaut = {}
 export const PetitsTags = {
   args: {
     size: 'sm',
+  },
+}
+
+export const AvecLimite = {
+  args: {
+    tags: [
+      { label: 'Tag 1' },
+      { label: 'Tag 2' },
+      { label: 'Tag 3' },
+      { label: 'Tag 4' },
+      { label: 'Tag 5' },
+      { label: 'Tag 6' },
+      { label: 'Tag 7' },
+      { label: 'Tag 8' },
+      { label: 'Tag 9' },
+      { label: 'Tag 10' },
+    ],
+    limit: 5,
   },
 }


### PR DESCRIPTION
Ajout d'une `Tooltip` dans `TagsList` afin d'afficher les tags masqués si la liste dépasse la limite imposée à l'affichage.

<img width="1246" height="494" alt="Capture d’écran 2026-01-27 à 14 39 10" src="https://github.com/user-attachments/assets/110104a7-ebb8-41fc-9e7f-d05aa67cacbc" />
