### PR TITLE
Déplacement du bouton "Centrer sur l'exploitation"

### DIFF
--- a/inertia/components/visualisation-left-side-bar.tsx
+++ b/inertia/components/visualisation-left-side-bar.tsx
@@ -62,7 +62,7 @@ export default function VisualisationLeftSideBar({
             className="fr-p-1w fr-m-1w"
             style={{ background: fr.colors.decisions.background.alt.blueFrance.default }}
           >
-            <div className="flex flex-wrap items-center justify-between gap-2 fr-mb-1w">
+            <div className="flex flex-col gap-4 fr-mb-1v">
               <Link
                 href={`/exploitations/${selectedExploitation.id}`}
                 as="h4"
@@ -73,9 +73,8 @@ export default function VisualisationLeftSideBar({
               <Button
                 priority="secondary"
                 size="small"
-                aria-label="Centrer sur l'exploitation"
                 iconId="fr-icon-crosshair-2-line"
-                className="flex justify-center fr-mt-2w"
+                className="flex justify-center"
                 onClick={() => {
                   if (selectedExploitation) {
                     mapRef.current?.centerOnExploitation(selectedExploitation)


### PR DESCRIPTION
Cette PR modifie le placement du bouton "Centrer sur l'exploitation" afin d'éviter un "écrasement" du contenu du bouton lorsque le titre prend trop de place.

### **Avant**
<img width="401" height="753" alt="Capture d’écran 2026-01-28 à 15 50 19" src="https://github.com/user-attachments/assets/c52662df-43ed-402f-aac0-ca4532286553" />

### **Après**
<img width="381" height="783" alt="Capture d’écran 2026-01-28 à 15 49 54" src="https://github.com/user-attachments/assets/7458ac14-97e3-4d4d-9c91-6054046bf221" />
