### PR TITLE
Gérer les contenus de type ReactNode dans LabelInfo

### DIFF
--- a/inertia/ui/LabelInfo/index.tsx
+++ b/inertia/ui/LabelInfo/index.tsx
@@ -8,6 +8,8 @@ export type LabelInfoProps = {
   size?: 'sm' | 'md'
 }
 export default function LabelInfo({ icon, label, info, size = 'md' }: LabelInfoProps) {
+  const isStringInfo = typeof info === 'string'
+
   return (
     <div className="flex">
       <div className="flex items-start">
@@ -30,7 +32,7 @@ export default function LabelInfo({ icon, label, info, size = 'md' }: LabelInfoP
 
       {info && (
         <div
-          className={`fr-text--${size} fr-ml-1w fr-mb-0 flex-1 break-words`}
+          className={`${isStringInfo ? `fr-text--${size} break-words` : ''} fr-ml-1w fr-mb-0 flex-1`}
           style={{
             color: fr.colors.decisions.text.mention.grey.default,
           }}


### PR DESCRIPTION
Correction de ce problème : https://github.com/MTES-MCT/vizeau/pull/221#discussion_r2737135345