### PR TITLE
Correction pour que Scalingo lance les migrations à chaque déploiement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "license": "UNLICENSED",
   "scripts": {
     "start": "cd build && node bin/server.js",
-    "build": "node ace build && cd build && npm ci --omit='dev'",
+    "build": "node ace build",
     "dev": "npx react-dsfr update-icons && node ace serve --hmr",
+    "scalingo-postbuild": "./scalingo-postbuild.sh",
     "test": "node ace test",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/scalingo-postbuild.sh
+++ b/scalingo-postbuild.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# This script is ran by Scalingo after each deployment.
+
+# Build the AdonisJS application
+node ace build
+cd build
+# Install production dependencies
+npm ci --omit='dev'
+# PORT is not set by Scalingo for non-web containers, but AdonisJS needs it to be defined at migration time
+export PORT=0
+# Run database migrations
+node ace migration:run --force


### PR DESCRIPTION
Cette PR déplace le processus de build sur Scalingo dans un script dédié scalingo-postbuild.sh.

Ce script lance maintenant systématiquement les migrations après déploiement.