### PR TITLE
Correction de la largeur de SelectorMenu

### DIFF
--- a/inertia/ui/SelectorMenu/index.tsx
+++ b/inertia/ui/SelectorMenu/index.tsx
@@ -34,7 +34,7 @@ export default function SelectorMenu<T extends string | number>({
         right: 0,
         background: fr.colors.decisions.background.default.grey.default,
         overflowY: 'auto',
-        width: '100%',
+        width: 'fit-content',
         maxHeight: '190px',
         overflowX: 'hidden'
       }}


### PR DESCRIPTION
### **Avant**
<img width="827" height="248" alt="Capture d’écran 2026-01-30 à 11 55 44" src="https://github.com/user-attachments/assets/4ad1ced2-41eb-4dbd-91d1-e15f0337b7e3" />

### **Après**
<img width="780" height="237" alt="Capture d’écran 2026-01-30 à 11 55 28" src="https://github.com/user-attachments/assets/5f9fb63a-3f32-4bfc-bcef-31f85bfa1551" />