### PR TITLE
Ajout de la gestion des titres dans les notes de journal de bord

### DIFF
--- a/app/controllers/log_entries_controller.ts
+++ b/app/controllers/log_entries_controller.ts
@@ -17,6 +17,8 @@ import User from '#models/user'
 import router from '@adonisjs/core/services/router'
 import { LogEntryTagDto } from '../dto/log_entry_tag_dto.js'
 import { ExploitationService } from '#services/exploitation_service'
+import { LogEntryDto } from '../dto/log_entry_dto.js'
+import { ExploitationDto } from '../dto/exploitation_dto.js'
 
 // Définition centralisée des noms d'événements pour ce contrôleur
 const EVENTS = {
@@ -103,9 +105,9 @@ export default class LogEntriesController {
     const logEntryAuthor = await User.find(logEntry.userId)
 
     return inertia.render('journal/id', {
-      logEntry: logEntry.serialize(),
+      logEntry: LogEntryDto.fromModel(logEntry),
       isCreator: logEntry.userId === user.id,
-      exploitation: exploitation.serialize(),
+      exploitation: ExploitationDto.fromModel(exploitation),
       user: logEntryAuthor?.serialize(),
       deleteEntryLogUrl: router
         .builder()
@@ -186,6 +188,7 @@ export default class LogEntriesController {
       await this.logEntryService.createLogEntry({
         userId: user.id,
         exploitationId: payload.params.exploitationId,
+        title: payload.title,
         notes: payload.notes,
         tags: payload.tags,
       })
@@ -220,6 +223,7 @@ export default class LogEntriesController {
 
     try {
       await this.logEntryService.updateLogEntry(id, user.id, params.exploitationId, {
+        title: payload.title,
         notes: payload.notes,
         tags: payload.tags,
       })

--- a/app/dto/log_entry_dto.ts
+++ b/app/dto/log_entry_dto.ts
@@ -9,6 +9,7 @@ export class LogEntryDto {
       id: logEntry.id,
       userId: logEntry.userId,
       exploitationId: logEntry.exploitationId,
+      title: logEntry.title,
       notes: logEntry.notes,
       createdAt: logEntry.createdAt.toISO() as string,
       updatedAt: logEntry.updatedAt.toISO() as string,

--- a/app/models/log_entry.ts
+++ b/app/models/log_entry.ts
@@ -23,6 +23,9 @@ export default class LogEntry extends BaseModel {
   }
 
   @column()
+  declare title: string | null
+
+  @column()
   declare notes: string | null
 
   @column()

--- a/app/services/log_entry_service.ts
+++ b/app/services/log_entry_service.ts
@@ -3,6 +3,7 @@ import { errors } from '@adonisjs/auth'
 
 export class LogEntryService {
   async createLogEntry(logData: {
+    title?: string | null
     notes?: string | null
     userId: string
     exploitationId: string
@@ -42,7 +43,7 @@ export class LogEntryService {
     id: string,
     userId: string,
     exploitationId: string,
-    logData: { notes?: string | null; tags?: number[] }
+    logData: { title?: string | null; notes?: string | null; tags?: number[] }
   ) {
     const logEntry = await LogEntry.findByOrFail({ id, exploitationId })
 
@@ -50,10 +51,9 @@ export class LogEntryService {
       throw errors.E_UNAUTHORIZED_ACCESS
     }
 
-    if (logData.notes !== undefined) {
-      logEntry.notes = logData.notes
-      await logEntry.save()
-    }
+    logEntry.merge(logData)
+    await logEntry.save()
+
     if (logData.tags !== undefined) {
       await logEntry.related('tags').sync(logData.tags)
     }

--- a/app/validators/log_entry.ts
+++ b/app/validators/log_entry.ts
@@ -1,11 +1,12 @@
 import vine from '@vinejs/vine'
 
 const logEntryFormFieldsValidator = {
-  notes: vine.string().maxLength(1000).nullable().optional().requiredIfMissing(['tags']),
+  title: vine.string().maxLength(255).nullable().optional().requiredIfMissing(['notes', 'tags']),
+  notes: vine.string().maxLength(1000).nullable().optional().requiredIfMissing(['title', 'tags']),
   tags: vine
     .array(vine.number().positive().withoutDecimals())
     .optional()
-    .requiredIfMissing(['notes']),
+    .requiredIfMissing(['title', 'notes']),
   params: vine.object({
     exploitationId: vine.string().uuid(),
   }),

--- a/database/migrations/1769795382057_alter_log_entries_table.ts
+++ b/database/migrations/1769795382057_alter_log_entries_table.ts
@@ -1,0 +1,18 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+import LogEntry from '#models/log_entry'
+
+export default class extends BaseSchema {
+  protected tableName = LogEntry.table
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('title').nullable()
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('title')
+    })
+  }
+}

--- a/inertia/components/exploitation-id/ExploitationLog.tsx
+++ b/inertia/components/exploitation-id/ExploitationLog.tsx
@@ -7,7 +7,7 @@ import Alert from '@codegouvfr/react-dsfr/Alert'
 import EmptyPlaceholder from '~/ui/EmptyPlaceholder'
 import Timeline, { TimelineItem } from '~/ui/Timeline'
 import ListItem from '~/ui/ListItem'
-import { truncateStr } from '~/functions/string'
+import { getLogEntryTitle } from '~/functions/log_entries'
 
 const deleteEntryLogModal = createModal({
   id: 'delete-entry-log-modal',
@@ -44,11 +44,7 @@ export function ExploitationLog({
       <ListItem
         variant="compact"
         key={logEntry.id}
-        title={
-          logEntry.notes
-            ? truncateStr(logEntry.notes, 90)
-            : new Date(logEntry.createdAt).toLocaleDateString()
-        }
+        title={getLogEntryTitle(logEntry)}
         href={`/exploitations/${exploitationId}/journal/${logEntry.id}`}
         tags={logEntry.tags?.map((tag) => ({ label: tag.name })) || []}
         metas={

--- a/inertia/components/exploitation-id/LogEntryForm.tsx
+++ b/inertia/components/exploitation-id/LogEntryForm.tsx
@@ -1,20 +1,18 @@
 import { Input } from '@codegouvfr/react-dsfr/Input'
 import SectionCard from '~/ui/SectionCard'
 import { TagSelector } from '~/components/exploitation-id/TagSelector'
+import { LogEntryFormData } from '~/pages/journal/creation'
+import { SetDataAction } from '@inertiajs/react'
 
 type EntryLogFormProps = {
-  data: {
-    id?: string
-    notes: string
-    tags: number[]
-  }
-  setData: (field: 'notes' | 'tags', value: any) => void
+  data: LogEntryFormData
+  setData: SetDataAction<LogEntryFormData>
   inputValue: string
   setInputValue: (val: string) => void
   disabled?: boolean
 }
 
-export function EntryLogForm({
+export function LogEntryForm({
   data,
   setData,
   inputValue,
@@ -25,12 +23,29 @@ export function EntryLogForm({
     <>
       {!disabled ? (
         <Input
+          label="Titre"
+          nativeInputProps={{
+            name: 'title',
+            maxLength: 255,
+            value: data.title,
+            onChange: (e) => setData('title', e.target.value),
+            readOnly: disabled,
+          }}
+        />
+      ) : (
+        <SectionCard size="small" background="secondary" icon="fr-icon-draft-line" title="Notes">
+          <p>{data.title || <i>Cette tâche n'a pas de titre.</i>}</p>
+        </SectionCard>
+      )}
+      {!disabled ? (
+        <Input
           textArea
           label="Note"
           nativeTextAreaProps={{
             name: 'notes',
             maxLength: 1000,
             value: data.notes,
+            rows: 5,
             onChange: (e) => setData('notes', e.target.value),
             readOnly: disabled,
           }}

--- a/inertia/functions/log_entries.ts
+++ b/inertia/functions/log_entries.ts
@@ -1,0 +1,19 @@
+import { LogEntryJson } from '../../types/models'
+import { truncateStr } from '~/functions/string'
+
+const MAX_TITLE_LENGTH = 90
+
+export function getLogEntryTitle(logEntry: LogEntryJson, titleLength = MAX_TITLE_LENGTH): string {
+  if (logEntry.title) {
+    return truncateStr(logEntry.title, titleLength)
+  }
+  if (logEntry.notes) {
+    return truncateStr(logEntry.notes, titleLength)
+  }
+  if (logEntry.createdAt) {
+    return new Date(logEntry.createdAt).toLocaleDateString()
+  }
+
+  // A log entry should always have at least one of these fields, but in case none are present:
+  return ''
+}

--- a/inertia/pages/journal/creation.tsx
+++ b/inertia/pages/journal/creation.tsx
@@ -1,7 +1,7 @@
 import Layout from '~/ui/layouts/layout'
 import { useState, FormEvent } from 'react'
 import { Head, useForm, router } from '@inertiajs/react'
-import { EntryLogForm } from '~/components/exploitation-id/EntryLogForm'
+import { LogEntryForm } from '~/components/exploitation-id/LogEntryForm'
 import { Breadcrumb } from '@codegouvfr/react-dsfr/Breadcrumb'
 import { Button } from '@codegouvfr/react-dsfr/Button'
 import { fr } from '@codegouvfr/react-dsfr'
@@ -10,16 +10,21 @@ import { InferPageProps } from '@adonisjs/inertia/types'
 import { Alert } from '@codegouvfr/react-dsfr/Alert'
 import { FlashMessages } from '~/components/flash-message'
 
+export type LogEntryFormData = {
+  id?: string
+  title: string
+  notes: string
+  tags: number[]
+}
+
 export default function TaskCreationPage({
   exploitation,
   createEntryLogUrl,
   flashMessages,
 }: InferPageProps<LogEntriesController, 'index'>) {
   const [inputValue, setInputValue] = useState('')
-  const { data, setData, post, resetAndClearErrors } = useForm<{
-    notes: string
-    tags: number[]
-  }>({
+  const { data, setData, post, resetAndClearErrors } = useForm<LogEntryFormData>({
+    title: '',
     notes: '',
     tags: [],
   })
@@ -61,12 +66,12 @@ export default function TaskCreationPage({
         <Alert
           small
           severity="info"
-          description="La création d'une tâche est possible lorsqu'au moins une note ou un tag est ajouté."
+          description="Veuillez remplir au moins un de ces champs pour créer la tâche."
         />
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
           <FlashMessages flashMessages={flashMessages} />
-          <EntryLogForm
+          <LogEntryForm
             data={data}
             setData={setData}
             inputValue={inputValue}
@@ -85,7 +90,10 @@ export default function TaskCreationPage({
               Retour
             </Button>
 
-            <Button type="submit" disabled={data.tags.length === 0 && data.notes === ''}>
+            <Button
+              type="submit"
+              disabled={data.tags.length === 0 && data.notes === '' && data.title === ''}
+            >
               Valider
             </Button>
           </div>

--- a/inertia/pages/journal/edition.tsx
+++ b/inertia/pages/journal/edition.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react'
 import { InferPageProps } from '@adonisjs/inertia/types'
 import LogEntriesController from '#controllers/log_entries_controller'
 import { Head, useForm, router } from '@inertiajs/react'
-import { EntryLogForm } from '~/components/exploitation-id/EntryLogForm'
+import { LogEntryForm } from '~/components/exploitation-id/LogEntryForm'
 import Layout from '~/ui/layouts/layout'
 import { Breadcrumb } from '@codegouvfr/react-dsfr/Breadcrumb'
 import { fr } from '@codegouvfr/react-dsfr'
 import { Button } from '@codegouvfr/react-dsfr/Button'
 import { FlashMessages } from '~/components/flash-message'
+import { LogEntryFormData } from '~/pages/journal/creation'
 
 export default function TaskEditionPage({
   logEntry,
@@ -17,12 +18,9 @@ export default function TaskEditionPage({
   isCreator,
 }: InferPageProps<LogEntriesController, 'getForEdition'>) {
   const [inputValue, setInputValue] = useState('')
-  const { data, setData, patch, resetAndClearErrors } = useForm<{
-    id: string
-    notes: string
-    tags: number[]
-  }>({
+  const { data, setData, patch, resetAndClearErrors } = useForm<LogEntryFormData>({
     id: logEntry.id,
+    title: logEntry.title || '',
     notes: logEntry.notes || '',
     tags: logEntry.tags?.map((tag: { id: number }) => tag.id) || [],
   })
@@ -63,7 +61,7 @@ export default function TaskEditionPage({
         <FlashMessages flashMessages={flashMessages} />
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <EntryLogForm
+          <LogEntryForm
             data={data}
             setData={setData}
             inputValue={inputValue}
@@ -83,7 +81,10 @@ export default function TaskEditionPage({
             </Button>
 
             {isCreator && (
-              <Button type="submit" disabled={data.tags.length === 0 && data.notes === ''}>
+              <Button
+                type="submit"
+                disabled={data.tags.length === 0 && data.notes === '' && data.title === ''}
+              >
                 Valider
               </Button>
             )}

--- a/inertia/pages/journal/id.tsx
+++ b/inertia/pages/journal/id.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { InferPageProps } from '@adonisjs/inertia/types'
 import LogEntriesController from '#controllers/log_entries_controller'
 import { createModal } from '@codegouvfr/react-dsfr/Modal'
@@ -11,9 +10,9 @@ import LogEntryInformationCard from '~/components/log-entry-id/LogEntryInformati
 import LogEntryTagsCard from '~/components/log-entry-id/LogEntryTagsCard'
 import LogEntryNoteCard from '~/components/log-entry-id/LogEntryNoteCard'
 import DeleteAlert from '~/ui/DeleteAlert'
-import { truncateStr } from '~/functions/string'
 import { router } from '@inertiajs/react'
 import { Alert } from '@codegouvfr/react-dsfr/Alert'
+import { getLogEntryTitle } from '~/functions/log_entries'
 
 export default function SingleTask({
   logEntry,
@@ -27,15 +26,7 @@ export default function SingleTask({
     isOpenedByDefault: false,
   })
 
-  const logEntryTitle = useMemo(() => {
-    if (logEntry.title) {
-      return logEntry.title
-    }
-    if (logEntry.notes) {
-      return truncateStr(logEntry.notes, 40)
-    }
-    return new Date(logEntry.createdAt).toLocaleDateString()
-  }, [logEntry])
+  const logEntryTitle = getLogEntryTitle(logEntry)
 
   return (
     <Layout>

--- a/types/models.ts
+++ b/types/models.ts
@@ -23,6 +23,7 @@ export type LogEntryTagJson = {
 
 export type LogEntryJson = {
   id: string
+  title: string | null
   notes: string | null
   userId: string
   exploitationId: string


### PR DESCRIPTION
Cette PR ajoute des titres dans les notes de journal de bord. Ce titre sera affiché en place de la note en elle-même s'il est fourni par l'animateur.

## Utilisation
Cette PR demande à faire évoluer le schéma de base de données, il faut donc lancer cette commande pour la tester: 
```bash
node ace migration:run
```

Closes #195 