### PR TITLE
Améliorer l'affichage de LabelInfo

### DIFF
--- a/inertia/ui/LabelInfo/index.tsx
+++ b/inertia/ui/LabelInfo/index.tsx
@@ -9,37 +9,58 @@ export type LabelInfoProps = {
 }
 export default function LabelInfo({ icon, label, info, size = 'md' }: LabelInfoProps) {
   const isStringInfo = typeof info === 'string'
+  const labelText = info ? label + ' : ' : label
 
   return (
-    <div className="flex">
-      <div className="flex items-start">
-        {icon && (
-          <span
-            className={`${icon} fr-icon--${size} fr-mr-1v`}
-            style={{ color: fr.colors.decisions.text.actionHigh.blueFrance.default }}
-            aria-hidden="true"
-          />
-        )}
+    <div className="flex items-start">
+      {icon && (
         <span
-          className={`fr-text--${size} fr-mb-0 w-fit flex-shrink-0 whitespace-nowrap`}
-          style={{
-            fontWeight: info ? 800 : 500,
-          }}
-        >
-          {info ? label + ' :' : label}
-        </span>
-      </div>
-
-      {info && (
-        <div
-          className={`${isStringInfo ? `fr-text--${size} break-words` : ''} fr-ml-1w fr-mb-0 flex-1`}
-          style={{
-            color: fr.colors.decisions.text.mention.grey.default,
-          }}
-        >
-          {info}
-        </div>
+          className={`${icon} fr-icon--${size} fr-mr-1v flex-shrink-0`}
+          style={{ color: fr.colors.decisions.text.actionHigh.blueFrance.default }}
+          aria-hidden="true"
+        />
       )}
+      <div className="flex-1 min-w-0">
+        {isStringInfo && info ? (
+          <p className={`fr-text--${size} fr-mb-0`}>
+            <span
+              style={{
+                fontWeight: 800,
+              }}
+            >
+              {labelText}
+            </span>
+            <span
+              style={{
+                color: fr.colors.decisions.text.mention.grey.default,
+              }}
+            >
+              {info}
+            </span>
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-1 items-start">
+            <span
+              className={`fr-text--${size} fr-mb-0 whitespace-nowrap`}
+              style={{
+                fontWeight: info ? 800 : 500,
+              }}
+            >
+              {labelText}
+            </span>
+            {info && (
+              <div
+                className="fr-mb-0 fr-ml-1v"
+                style={{
+                  color: fr.colors.decisions.text.mention.grey.default,
+                }}
+              >
+                {info}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
### **Avant**
<img width="347" height="377" alt="Capture d’écran 2026-02-02 à 09 56 07" src="https://github.com/user-attachments/assets/56fe0d9e-b65d-4632-a26d-1c352dd9c2a0" />

### **Après**
<img width="344" height="282" alt="Capture d’écran 2026-02-02 à 09 57 54" src="https://github.com/user-attachments/assets/e05236a1-1163-4392-8226-fc3f9bb027d4" />
<img width="332" height="320" alt="Capture d’écran 2026-02-02 à 09 58 15" src="https://github.com/user-attachments/assets/72f711d4-a3d1-4d1a-9158-fa0f9d9480be" />
