### PR TITLE
Mise à niveau d'Adonis pour corriger des failles de sécurité

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@adonisjs/auth": "^9.4.0",
-        "@adonisjs/core": "^6.19.3",
+        "@adonisjs/core": "^6.20.0",
         "@adonisjs/cors": "^2.2.1",
         "@adonisjs/inertia": "^3.1.1",
         "@adonisjs/lucid": "^21.8.2",
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@adonisjs/bodyparser": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/@adonisjs/bodyparser/-/bodyparser-10.1.2.tgz",
-      "integrity": "sha512-Lp419XmpMOq878Ee9V1Iqu2vGHEFBMUrUK3A3Fz3/dCP70E40esRf7wzTvRe+YZfXqQLaz1XCE0xfy3lj9wA9Q==",
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@adonisjs/bodyparser/-/bodyparser-10.1.3.tgz",
+      "integrity": "sha512-FtxUbVYDHrW94z4+w1dOTq31TLkD3wAoyVVCQLY9irNOBrjSH9ucKP4tq8tq2jeQffoRh3R2j7jp2VW8psSQcA==",
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.2",
@@ -231,14 +231,14 @@
       }
     },
     "node_modules/@adonisjs/core": {
-      "version": "6.19.3",
-      "resolved": "https://registry.npmjs.org/@adonisjs/core/-/core-6.19.3.tgz",
-      "integrity": "sha512-2XDksJ2In0Jh/ZDRs+dYARhZ01tONtZ4c8MGI5CvwSUcM4WMYUs2GyXGOYihfqtYOhG2URe7iq2Ou+e5k5VjgA==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@adonisjs/core/-/core-6.20.0.tgz",
+      "integrity": "sha512-2DpPlQALzPScD5yzDJ4O7ZyzUt3tqHj4zjQDcO2CifhvOnli9tw0xsJpmPVbnogu1Z//N0YB1esOCD7JPmWLxg==",
       "license": "MIT",
       "dependencies": {
         "@adonisjs/ace": "^13.4.0",
         "@adonisjs/application": "^8.4.2",
-        "@adonisjs/bodyparser": "^10.1.2",
+        "@adonisjs/bodyparser": "^10.1.3",
         "@adonisjs/config": "^5.0.3",
         "@adonisjs/encryption": "^6.0.2",
         "@adonisjs/env": "^6.2.0",
@@ -439,18 +439,16 @@
       }
     },
     "node_modules/@adonisjs/fold/node_modules/@poppinss/utils": {
-      "version": "7.0.0-next.3",
-      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.0-next.3.tgz",
-      "integrity": "sha512-Z+3kolI/gdjTQRJWRiZTEk6r6QOeGLesfmdc8ISSeHlyUg0mTnVdi08/rwOcRJD6dLdwBGTDUf7lK2K7GpT4ww==",
+      "version": "7.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/@poppinss/utils/-/utils-7.0.0-next.7.tgz",
+      "integrity": "sha512-Jwc6YqiLf8wAarEpC2bzamq5XIe3i553LeCzZhqYamSK1zZjYoa6tEPjKq1ASARjuNpYQAj96TLBw/yXJJDF/A==",
       "license": "MIT",
       "dependencies": {
-        "@poppinss/exception": "^1.2.1",
+        "@poppinss/exception": "^1.2.3",
         "@poppinss/object-builder": "^1.1.0",
-        "@poppinss/string": "^1.6.0",
-        "@poppinss/types": "^1.1.0",
-        "flattie": "^1.1.1",
-        "safe-stable-stringify": "^2.5.0",
-        "secure-json-parse": "^4.0.0"
+        "@poppinss/string": "^1.7.1",
+        "@poppinss/types": "^1.2.1",
+        "flattie": "^1.1.1"
       }
     },
     "node_modules/@adonisjs/hash": {
@@ -2393,15 +2391,6 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
-    "node_modules/@lukeed/ms": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
-      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@mapbox/geojson-rewind": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
@@ -2740,9 +2729,9 @@
       }
     },
     "node_modules/@poppinss/exception": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.2.tgz",
-      "integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "license": "MIT"
     },
     "node_modules/@poppinss/hooks": {
@@ -2776,9 +2765,9 @@
       }
     },
     "node_modules/@poppinss/middleware": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@poppinss/middleware/-/middleware-3.2.6.tgz",
-      "integrity": "sha512-KcZeLlJ0EV+PLTlGGq3+5IqwpGOUTuR3ucfwyPOXeQegQKtyIF9i2HryKklY1qhfLhhTwFC9M6v1nTfdHQM6tA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@poppinss/middleware/-/middleware-3.2.7.tgz",
+      "integrity": "sha512-MZC0Z97ozSz+PpfyxUPUy/ImuthpqvBbY7qku7f4Q2maHz+2uXfchfO8OggXLS6zEJ078l+jpAHZ2rDIRdjeVg==",
       "license": "MIT"
     },
     "node_modules/@poppinss/multiparty": {
@@ -2814,25 +2803,21 @@
       }
     },
     "node_modules/@poppinss/string": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@poppinss/string/-/string-1.7.0.tgz",
-      "integrity": "sha512-IuCtWaUwmJeAdby0n1a5cTYsBLe7fPymdc4oNTTl1b6l+Ok+14XpSX0ILOEU6UtZ9D2XI3f4TVUh4Titkk1xgw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/string/-/string-1.7.1.tgz",
+      "integrity": "sha512-OrLzv/nGDU6l6dLXIQHe8nbNSWWfuSbpB/TW5nRpZFf49CLuQlIHlSPN9IdSUv2vG+59yGM6LoibsaHn8B8mDw==",
       "license": "MIT",
       "dependencies": {
-        "@lukeed/ms": "^2.0.2",
-        "@types/bytes": "^3.1.5",
         "@types/pluralize": "^0.0.33",
-        "bytes": "^3.1.2",
         "case-anything": "^3.1.2",
         "pluralize": "^8.0.0",
-        "slugify": "^1.6.6",
-        "truncatise": "^0.0.8"
+        "slugify": "^1.6.6"
       }
     },
     "node_modules/@poppinss/types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@poppinss/types/-/types-1.2.0.tgz",
-      "integrity": "sha512-kHwS1lDC/IQeqaBEbuJuWNVt46OGdQQN6+wvyq+GFa2YWV33TAGDku7dkeXDSxddt6UX+URWCLsJ+JRJWCCZLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/types/-/types-1.2.1.tgz",
+      "integrity": "sha512-qUYnzl0m9HJTWsXtr8Xo7CwDx6wcjrvo14bOVbIMIlKJCzKrm3LX55dRTDr1/x4PpSvKVgmxvC6Ly2YiqXKOvQ==",
       "license": "MIT"
     },
     "node_modules/@poppinss/utils": {
@@ -4241,12 +4226,6 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
-    },
-    "node_modules/@types/bytes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@types/bytes/-/bytes-3.1.5.tgz",
-      "integrity": "sha512-VgZkrJckypj85YxEsEavcMmmSOIzkUHqWmM4CCyia5dc54YwsXzJ5uT4fYxBQNEXx+oF1krlhgCbvfubXqZYsQ==",
-      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -8038,9 +8017,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9273,15 +9252,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-function": {
@@ -9958,9 +9941,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.1.1.tgz",
-      "integrity": "sha512-3qqVfpJtRQUCAOs4rTOEwLH6mwJJ/CSAlbis8fKOiMzTtXh0HN/VLsn3UWVTJ7U8DsWmxeNon2IpGb+wORXH4g==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.0.tgz",
+      "integrity": "sha512-0GNPNzHXBKw6U/InGe79A3Crzyk9bcSyObF9/Gfo9DLEf5qj5RF50RSjsu0W1rZ6ZqRGdzDFCRBQvi9/rSGPtA==",
       "license": "MIT",
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
@@ -10510,18 +10493,47 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/react": {
@@ -11960,12 +11972,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/truncatise": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/truncatise/-/truncatise-0.0.8.tgz",
-      "integrity": "sha512-cXzueh9pzBCsLzhToB4X4gZCb3KYkrsAcBAX97JnazE74HOl3cpBJYEV7nabHeG/6/WXCU5Yujlde/WPBUwnsg==",
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@adonisjs/auth": "^9.4.0",
-    "@adonisjs/core": "^6.19.3",
+    "@adonisjs/core": "^6.20.0",
     "@adonisjs/cors": "^2.2.1",
     "@adonisjs/inertia": "^3.1.1",
     "@adonisjs/lucid": "^21.8.2",


### PR DESCRIPTION
Cette PR met à jour le framework Adonis en version 6.20.0 afin de corriger deux failles de sécurité liées au parsing de requêtes HTTP.

Plus d'infos dans les [notes de release d'Adonis](https://github.com/adonisjs/core/releases/tag/v6.20.0).