### PR TITLE
Changer le texte du sélecteur de millésime

### DIFF
--- a/inertia/pages/visualisation.tsx
+++ b/inertia/pages/visualisation.tsx
@@ -226,8 +226,8 @@ export default function VisualisationPage({
                   },
                 }}
                 options={[
-                  { value: '2024', label: '2024' },
-                  { value: '2023', label: '2023' },
+                  { value: '2024', label: 'RPG 2024' },
+                  { value: '2023', label: 'RPG 2023' },
                 ]}
               />
             </div>


### PR DESCRIPTION
Pour plus de clarté, le texte du sélecteur de millésime ajoute le préfixe "RPG".

---
<img width="503" height="88" alt="Capture d’écran 2026-02-17 à 11 10 12" src="https://github.com/user-attachments/assets/5d044660-5bbe-44ea-8b11-601b50e435d0" />

Close #267 
