### PR TITLE
Ajout de l'étape manquante dans le fil d'Ariane

### DIFF
--- a/inertia/pages/exploitations/edition.tsx
+++ b/inertia/pages/exploitations/edition.tsx
@@ -47,7 +47,8 @@ export default function ExploitationEditionPage({
             currentPageLabel="Modifier l'exploitation agricole"
             homeLinkProps={{ href: '/' }}
             segments={[
-              { label: 'Liste des exploitations agricoles', linkProps: { href: '/exploitations' } },
+              { label: 'Exploitations agricoles', linkProps: { href: '/exploitations' } },
+              { label: initialExploitation.name, linkProps: { href: `/exploitations/${initialExploitation.id}` } },
             ]}
           />
         </div>


### PR DESCRIPTION
Cette PR permet de rajouter dans le fil d'Ariane de la page d'édition d'une exploitation de retourner à la page de consultation de l'exploitation agricole.

### **Avant**
<img width="1322" height="258" alt="Capture d’écran 2026-02-18 à 15 24 48" src="https://github.com/user-attachments/assets/aeb17a2b-40e1-4d60-9f89-382ea83b3ffd" />

### **Après**
<img width="1310" height="229" alt="Capture d’écran 2026-02-18 à 15 24 28" src="https://github.com/user-attachments/assets/96b92f9e-daa0-4a09-8886-a6efac34a3d1" />

Close #281 
