### PR TITLE
Suppression de document

### DIFF
--- a/app/validators/log_entry.ts
+++ b/app/validators/log_entry.ts
@@ -58,3 +58,9 @@ export const downloadDocumentValidator = vine.compile(
     }),
   })
 )
+
+export const destroyDocumentValidator = vine.compile(
+  vine.object({
+    documentId: vine.number().positive().withoutDecimals(),
+  })
+)

--- a/inertia/components/exploitation-id/LogEntryForm.tsx
+++ b/inertia/components/exploitation-id/LogEntryForm.tsx
@@ -4,11 +4,12 @@ import { TagSelector } from '~/components/exploitation-id/TagSelector'
 import { LogEntryFormData } from '~/pages/journal/creation'
 import { SetDataAction } from '@inertiajs/react'
 import { formatDateFr } from '~/functions/date'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Checkbox } from '@codegouvfr/react-dsfr/Checkbox'
 import { Upload } from '@codegouvfr/react-dsfr/Upload'
-import FileItemsList from '~/ui/FileItemList'
 import { LogEntryDocumentJson } from '../../../types/models'
+import { Button } from '@codegouvfr/react-dsfr/Button'
+import { LogEntryDocumentList } from '~/components/log-entry-id/LogEntryDocumentList'
 
 type EntryLogFormProps = {
   data: LogEntryFormData
@@ -16,6 +17,7 @@ type EntryLogFormProps = {
   inputValue: string
   setInputValue: (val: string) => void
   existingDocuments: Array<LogEntryDocumentJson>
+  deleteDocumentUrl?: string
   disabled?: boolean
 }
 
@@ -25,9 +27,11 @@ export function LogEntryForm({
   inputValue,
   setInputValue,
   existingDocuments,
+  deleteDocumentUrl,
   disabled = false,
 }: EntryLogFormProps) {
   const [displayDocSubForm, setDisplayDocSubForm] = useState(existingDocuments.length > 0)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   return (
     <>
       {!disabled ? (
@@ -112,37 +116,49 @@ export function LogEntryForm({
           icon="fr-icon-attachment-line"
           title="Documents"
         >
-          <Upload
-            label=""
-            hint="Format PDF, maximum 10 Mo"
-            multiple={true}
-            disabled={disabled}
-            nativeInputProps={{
-              accept: 'application/pdf',
-              onChange: (e) => {
-                if (e.target.files) {
-                  const files = []
-                  for (let i = 0; i < e.target.files.length; i++) {
-                    files.push(e.target.files[i])
+          <div className="flex">
+            <Upload
+              label=""
+              hint="Format PDF, maximum 10 Mo"
+              multiple={true}
+              disabled={disabled}
+              className="flex-1"
+              nativeInputProps={{
+                accept: 'application/pdf',
+                onChange: (e) => {
+                  if (e.target.files) {
+                    const files = []
+                    for (let i = 0; i < e.target.files.length; i++) {
+                      files.push(e.target.files[i])
+                    }
+                    setData('documents', files)
                   }
-                  setData('documents', files)
-                }
-              },
-            }}
-          />
+                },
+                ref: fileInputRef,
+              }}
+            />
+            <div className="flex items-end">
+              <Button
+                type="button"
+                priority="tertiary"
+                onClick={() => {
+                  setData('documents', [])
+                  if (fileInputRef.current) {
+                    fileInputRef.current.files = new DataTransfer().files
+                  }
+                }}
+              >
+                Réinitialiser la sélection
+              </Button>
+            </div>
+          </div>
           {existingDocuments && existingDocuments.length > 0 && (
             <>
               <div className="fr-mt-2w fr-mb-1w text-md font-bold">Fichiers déjà téléchargés :</div>
-              <div className="bg-white">
-                <FileItemsList
-                  files={existingDocuments?.map((document) => ({
-                    name: document.name,
-                    href: document.href,
-                    size: document.sizeInBytes,
-                    format: 'PDF',
-                  }))}
-                />
-              </div>
+              <LogEntryDocumentList
+                documents={existingDocuments}
+                deleteDocumentUrl={deleteDocumentUrl}
+              />
             </>
           )}
         </SectionCard>

--- a/inertia/components/flash-message.tsx
+++ b/inertia/components/flash-message.tsx
@@ -34,7 +34,6 @@ export function FlashMessages({
   return (
     <>
       {Object.entries(flashMessages).map(([type, fm], i) => {
-        // Log an error if the flash message is null or undefined, but continue rendering the other messages
         if (!fm) {
           return null
         }

--- a/inertia/components/log-entry-id/LogEntryDocumentList.tsx
+++ b/inertia/components/log-entry-id/LogEntryDocumentList.tsx
@@ -1,0 +1,68 @@
+import FileItemsList from '~/ui/FileItemList'
+import { router } from '@inertiajs/react'
+import { LogEntryDocumentJson } from '../../../types/models'
+import { createModal } from '@codegouvfr/react-dsfr/Modal'
+import { Alert } from '@codegouvfr/react-dsfr/Alert'
+import { useState } from 'react'
+
+const deleteDocumentModal = createModal({
+  id: 'delete-document-modal',
+  isOpenedByDefault: false,
+})
+
+export function LogEntryDocumentList({
+  documents,
+  deleteDocumentUrl,
+}: {
+  documents: LogEntryDocumentJson[]
+  deleteDocumentUrl?: string
+}) {
+  const [documentIdToDelete, setDocumentIdToDelete] = useState<number | null>(null)
+
+  return (
+    <div className="bg-white">
+      <FileItemsList
+        files={documents.map((document) => ({
+          name: document.name,
+          href: document.href,
+          size: document.sizeInBytes,
+          format: 'PDF',
+          deletable: deleteDocumentUrl !== undefined,
+        }))}
+        onDelete={(_, index) => {
+          if (!deleteDocumentUrl) return
+
+          setDocumentIdToDelete(documents[index].id)
+          deleteDocumentModal.open()
+        }}
+      />
+      <deleteDocumentModal.Component
+        title=""
+        size="large"
+        buttons={[
+          { children: 'Annuler', doClosesModal: true, type: 'button' },
+          {
+            children: 'Supprimer le document',
+            onClick: () => {
+              if (!deleteDocumentUrl) return
+
+              router.delete(deleteDocumentUrl, {
+                data: { documentId: documentIdToDelete },
+                onSuccess: () => {
+                  setDocumentIdToDelete(null)
+                },
+              })
+            },
+            type: 'button',
+          },
+        ]}
+      >
+        <Alert
+          severity="error"
+          title="Suppression d'un document"
+          description="Vous êtes sur le point de supprimer ce document, voulez-vous continuer ?"
+        />
+      </deleteDocumentModal.Component>
+    </div>
+  )
+}

--- a/inertia/pages/journal/edition.tsx
+++ b/inertia/pages/journal/edition.tsx
@@ -9,6 +9,7 @@ import { fr } from '@codegouvfr/react-dsfr'
 import { Button } from '@codegouvfr/react-dsfr/Button'
 import { FlashMessages } from '~/components/flash-message'
 import { LogEntryFormData } from '~/pages/journal/creation'
+import { getLogEntryTitle } from '~/functions/log_entries'
 
 export default function TaskEditionPage({
   logEntry,
@@ -16,6 +17,7 @@ export default function TaskEditionPage({
   exploitation,
   flashMessages,
   isCreator,
+  deleteDocumentUrl,
 }: InferPageProps<LogEntriesController, 'getForEdition'>) {
   const [inputValue, setInputValue] = useState('')
   const { data, setData, patch, resetAndClearErrors } = useForm<LogEntryFormData>({
@@ -56,6 +58,10 @@ export default function TaskEditionPage({
                 label: exploitation.name,
                 linkProps: { href: `/exploitations/${exploitation.id}` },
               },
+              {
+                label: getLogEntryTitle(logEntry),
+                linkProps: { href: `/exploitations/${exploitation.id}/journal/${logEntry.id}` },
+              },
             ]}
           />
         </div>
@@ -70,6 +76,7 @@ export default function TaskEditionPage({
             inputValue={inputValue}
             setInputValue={setInputValue}
             existingDocuments={logEntry.documents || []}
+            deleteDocumentUrl={deleteDocumentUrl}
             disabled={!isCreator}
           />
           <div className="flex w-full items-center justify-end gap-3">

--- a/inertia/pages/journal/id.tsx
+++ b/inertia/pages/journal/id.tsx
@@ -15,7 +15,8 @@ import { Alert } from '@codegouvfr/react-dsfr/Alert'
 import { getLogEntryTitle } from '~/functions/log_entries'
 import TruncatedText from '~/ui/TruncatedText'
 import SectionCard from '~/ui/SectionCard'
-import FileItemsList from '~/ui/FileItemList'
+import { LogEntryDocumentList } from '~/components/log-entry-id/LogEntryDocumentList'
+import EmptyPlaceholder from '~/ui/EmptyPlaceholder'
 
 export default function SingleTask({
   logEntry,
@@ -24,6 +25,7 @@ export default function SingleTask({
   user,
   deleteEntryLogUrl,
   completeEntryLogUrl,
+  deleteDocumentUrl,
 }: InferPageProps<LogEntriesController, 'get'>) {
   const deleteEntryLogModal = createModal({
     id: 'delete-entry-log-modal',
@@ -128,17 +130,16 @@ export default function SingleTask({
                 icon="fr-icon-attachment-line"
                 title="Documents"
               >
-                {logEntry.documents && logEntry.documents.length > 0 && (
-                  <div className="bg-white">
-                    <FileItemsList
-                      files={logEntry.documents.map((document) => ({
-                        name: document.name,
-                        href: document.href,
-                        size: document.sizeInBytes,
-                        format: 'PDF',
-                      }))}
-                    />
-                  </div>
+                {logEntry.documents && logEntry.documents.length > 0 ? (
+                  <LogEntryDocumentList
+                    documents={logEntry.documents}
+                    deleteDocumentUrl={deleteDocumentUrl}
+                  />
+                ) : (
+                  <EmptyPlaceholder
+                    illustrativeIcon="fr-icon-attachment-line"
+                    label="Aucun document associé à cette tâche."
+                  />
                 )}
               </SectionCard>
             </div>

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -105,5 +105,8 @@ router
     router
       .get('journal-document/:documentId', [LogEntriesController, 'downloadDocument'])
       .as('log_entries.downloadDocument')
+    router
+      .delete('journal-document', [LogEntriesController, 'destroyDocument'])
+      .as('log_entries.destroyDocument')
   })
   .use(middleware.auth())


### PR DESCRIPTION
Dépend de #286 

Cette PR propose la suppression de documents liés à une entrée de journal de bord. Ces documents peuvent être supprimés via la page d'entrée de journal ou dans le formulaire d'édition d'entrée de journal.

Cette PR ajoute aussi la possibilité de réinitialiser le champ d'upload de document avant envoi.

Elle corrige aussi quelques problèmes d'intégration:
 - Le fil d'ariane sur la page d'édition d'entrée de journal ramène maintenant à la page d'entrée de journal.
 - Il y a un placeholder sur la page d'entrée de journal quand il n'y a pas de document associé.

Closes #259 