### PR TITLE
Ajout d'une alerte quand il manque l'adresse de l'exploitation

### DIFF
--- a/inertia/components/visualisation-left-side-bar.tsx
+++ b/inertia/components/visualisation-left-side-bar.tsx
@@ -107,20 +107,41 @@ export default function VisualisationLeftSideBar({
                   borderBottom: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
                 }}
               >
-                <Button
-                  priority="secondary"
-                  size="small"
-                  iconId="fr-icon-crosshair-2-line"
-                  className="flex justify-center"
-                  onClick={() => {
-                    if (selectedExploitation) {
-                      mapRef.current?.centerOnExploitation(selectedExploitation)
-                    }
-                  }}
-                  style={{ whiteSpace: 'nowrap', width: '100%' }}
-                >
-                  Centrer sur l'exploitation
-                </Button>
+                <div className="flex flex-col gap-2">
+                  <Button
+                    priority="secondary"
+                    size="small"
+                    iconId="fr-icon-crosshair-2-line"
+                    className="flex justify-center"
+                    disabled={!selectedExploitation?.location}
+                    onClick={() => {
+                      if (selectedExploitation) {
+                        mapRef.current?.centerOnExploitation(selectedExploitation)
+                      }
+                    }}
+                    style={{ whiteSpace: 'nowrap', width: '100%' }}
+                  >
+                    Centrer sur l'exploitation
+                  </Button>
+
+                  {!selectedExploitation?.location && (
+                    <Alert
+                      small
+                      severity="info"
+                      description={
+                        <div>
+                          L'exploitation agricole n'a pas de coordonnées définies.{' '}
+                          <Link
+                            href={`/exploitations/edition/${selectedExploitation.id}?step=2`}
+                            className="underline"
+                          >
+                            Ajouter une adresse
+                          </Link>
+                        </div>
+                      }
+                    />
+                  )}
+                </div>
 
                 <ParcellesManager
                   editMode={editMode}


### PR DESCRIPTION
Cette pull request améliore l’expérience utilisateur dans le composant VisualisationLeftSideBar en optimisant le comportement du bouton « Centrer sur l’exploitation » lorsqu’une exploitation ne dispose pas de données de localisation, et en fournissant un retour plus clair aux utilisateurs. Les principales évolutions sont présentées ci-dessous :

* Le bouton « Centrer sur l’exploitation » est désormais désactivé lorsque l’exploitation sélectionnée ne possède pas de localisation définie, empêchant ainsi les utilisateurs de tenter une action indisponible.

* Une Alert informative est affichée lorsque l’exploitation sélectionnée ne dispose pas de coordonnées, guidant les utilisateurs pour ajouter une adresse grâce à un lien direct vers la page de modification de l’exploitation.

<img width="479" height="1120" alt="Capture d’écran 2026-02-20 à 12 04 10" src="https://github.com/user-attachments/assets/10513711-2ebc-4a64-b02c-d8b94dcfd10a" />



Close #284 