### PR TITLE
Correction d'un accès problématique à l'objet user

### DIFF
--- a/config/inertia.ts
+++ b/config/inertia.ts
@@ -13,7 +13,7 @@ const inertiaConfig = defineConfig({
    * Data that should be shared with all rendered pages
    */
   sharedData: {
-    user: (ctx) => ctx.inertia.always(() => ctx.auth.user as User),
+    user: (ctx) => ctx.inertia.always(() => ctx.auth?.user as User),
     flashMessages: (ctx) =>
       ctx.inertia.always(
         () => ctx.session.flashMessages.toJSON() as Record<FlashMessageType, FlashMessageValue>


### PR DESCRIPTION
Les logs en production sont pollués de messages `"message":"Cannot read properties of undefined (reading 'user')"`. 
La condition de déclenchement n'est pas claire, mais dans certaines requêtes, l'objet `auth` n'est pas défini et l'accès à `auth.user` échoue. 

Cette correction permet d'éviter ce problème pour réduire la production de logs inutiles. Aucun changement n'est à prévoir côté fonctionnement de l'app, l'objet `auth` étant toujours défini en conditions normales, mêmes quand il n'y a pas d'utilisateur connecté.