### PR TITLE
Ajout d'un placeholder manquant

### DIFF
--- a/inertia/components/exploitation-id/exploitation-left-sidebar.tsx
+++ b/inertia/components/exploitation-id/exploitation-left-sidebar.tsx
@@ -181,13 +181,21 @@ export default function ExploitationLeftSidebar({
             />
           </div>
           {exploitations.length === 0 ? (
-            <EmptyPlaceholder
-              label="Aucune exploitation enregistrée"
-              buttonLabel="Ajouter une première exploitation"
-              buttonIcon="fr-icon-add-line"
-              handleClick={() => router.visit('/exploitations/creation')}
-              pictogram={LocationFrance}
-            />
+            queryString?.recherche ? (
+              <EmptyPlaceholder label="Aucun résultat trouvé" pictogram={LocationFrance} />
+            ) : (
+              <EmptyPlaceholder
+                label={
+                  queryString?.recherche
+                    ? `Aucun résultat trouvé pour "${queryString.recherche}"`
+                    : 'Aucune exploitation enregistrée'
+                }
+                buttonLabel="Ajouter une première exploitation"
+                buttonIcon="fr-icon-add-line"
+                handleClick={() => router.visit('/exploitations/creation')}
+                pictogram={LocationFrance}
+              />
+            )
           ) : (
             exploitations.map((exploitation, index) => (
               <div


### PR DESCRIPTION
Ajout du placeholder manquant dans la page visualisation lorsque aucune exploitation, n'a été créée.
### **Avant**
<img width="939" height="966" alt="Capture d’écran 2026-02-23 à 09 02 55" src="https://github.com/user-attachments/assets/278ef5a2-f2f1-4498-a268-460329ddc2ac" />


### **Après**
<img width="616" height="918" alt="Capture d’écran 2026-02-23 à 09 39 21" src="https://github.com/user-attachments/assets/49706ac7-babf-4601-991e-c5472ff5a966" />

Close #293 