### PR TITLE
Correction des couleurs des légendes

### DIFF
--- a/inertia/ui/LegendItem/index.tsx
+++ b/inertia/ui/LegendItem/index.tsx
@@ -26,7 +26,12 @@ export default function LegendItem({
         {
           label: (
             <div className="flex items-center gap-2">
-              {color && <div className={`w-3 h-3 rounded-full flex-shrink-0 ${color}`} />}
+              {color && (
+                <div
+                  className={`w-3 h-3 rounded-full flex-shrink-0`}
+                  style={{ backgroundColor: color }}
+                />
+              )}
               <span className="fr-text--sm fr-mb-0 flex items-center gap-1">
                 {label}
                 {hint && <Tooltip kind="hover" title={hint} />}


### PR DESCRIPTION
Cette PR corrige l'affichage des couleurs de la légende des différents types de cultures.

### **Avant**
<img width="349" height="904" alt="Capture d’écran 2026-02-23 à 15 12 25" src="https://github.com/user-attachments/assets/e8238529-49e4-43fd-ac4b-470a7360e3f2" />

### **Après**
<img width="303" height="810" alt="Capture d’écran 2026-02-23 à 15 12 58" src="https://github.com/user-attachments/assets/d7ad68a8-93fa-49d3-806b-9e97d6dd6625" />
