### PR TITLE
Améliorer la visibilité du lien vers l'exploitation

### DIFF
--- a/inertia/components/exploitation-id/exploitation-left-sidebar.tsx
+++ b/inertia/components/exploitation-id/exploitation-left-sidebar.tsx
@@ -89,18 +89,19 @@ export default function ExploitationLeftSidebar({
                 className="flex items-center gap-2"
                 style={{ color: fr.colors.decisions.text.actionHigh.blueFrance.default }}
               >
-                <span className="fr-icon-arrow-right-line" />
-                <Link
-                  href={`/exploitations/${selectedExploitation.id}`}
-                  style={{ backgroundImage: 'none' }}
+                <span className="fr-icon-arrow-right-line" aria-hidden="true" />
+
+                <h4
+                  className="fr-m-0 font-bold fr-text--lead underline"
+                  style={{ color: 'inherit' }}
                 >
-                  <h4
-                    className="fr-m-0 font-bold fr-text--lead underline"
-                    style={{ color: 'inherit' }}
+                  <Link
+                    href={`/exploitations/${selectedExploitation.id}`}
+                    style={{ backgroundImage: 'none' }}
                   >
                     {selectedExploitation?.name}
-                  </h4>
-                </Link>
+                  </Link>
+                </h4>
               </div>
               <div
                 className="flex flex-col gap-2 fr-mb-3v fr-pb-3v"


### PR DESCRIPTION
Cette pull request met à jour le composant `ExploitationLeftSidebar` afin d’améliorer la présentation visuelle et l’accessibilité du nom de l’exploitation sélectionnée. La modification la plus importante consiste à encapsuler le nom de l’exploitation et son lien dans un conteneur stylisé avec une icône, rendant l’interface plus intuitive et visuellement plus attrayante.

### **Avant**
<img width="615" height="960" alt="Capture d’écran 2026-02-26 à 16 33 46" src="https://github.com/user-attachments/assets/8d8f9c4b-9fea-46d7-ae03-430e5052eb44" />

### **Après**
<img width="614" height="961" alt="Capture d’écran 2026-02-26 à 16 33 31" src="https://github.com/user-attachments/assets/e3353495-7f45-47e4-a655-4e2f0c10e311" />
