### PR TITLE
Amélioration des couleurs des types de cultures

### DIFF
--- a/inertia/functions/cultures-group.tsx
+++ b/inertia/functions/cultures-group.tsx
@@ -15,7 +15,7 @@ export const GROUPES_CULTURAUX: { [key: string]: GroupeCulturauxItem } = {
   2: {
     label: 'Maïs grain et ensilage',
     code_group: 2,
-    color: '#f8d200',
+    color: '#F8D200',
   },
   3: {
     label: 'Orge',


### PR DESCRIPTION
Cette PR modifie les couleurs attribuées aux types de cultures qui avaient été récupérées sur le [Registre Parcellaire Graphique de Géoportail](https://www.geoportail.gouv.fr/donnees/registre-parcellaire-graphique-rpg-2007).
Ces couleurs étaient parfois trop intenses et gênaient le confort de l'utilisateur.

### **Avant**
<img width="258" height="926" alt="Capture d’écran 2026-03-05 à 10 46 59" src="https://github.com/user-attachments/assets/06124ffc-3dbf-430c-a5be-8a0977e5fe30" />

### **Après**
<img width="261" height="807" alt="Capture d’écran 2026-03-05 à 10 46 47" src="https://github.com/user-attachments/assets/c3fb51c3-6483-4674-aa7a-b164bd9487a8" />

Close #317 