### PR TITLE
Ajout d'un hook git pré-push qui vérifie que le projet est buildable

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run format

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "eslint": "^9.39.3",
         "eslint-plugin-storybook": "^10.0.0",
         "hot-hook": "^0.4.0",
+        "husky": "^9.1.7",
         "pino-pretty": "^13.0.0",
         "playwright": "^1.56.1",
         "prettier": "^3.5.3",
@@ -9917,6 +9918,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "prepare": "husky"
   },
   "imports": {
     "#controllers/*": "./app/controllers/*.js",
@@ -62,6 +63,7 @@
     "eslint": "^9.39.3",
     "eslint-plugin-storybook": "^10.0.0",
     "hot-hook": "^0.4.0",
+    "husky": "^9.1.7",
     "pino-pretty": "^13.0.0",
     "playwright": "^1.56.1",
     "prettier": "^3.5.3",


### PR DESCRIPTION
Pour éviter des déploiements échoués sur Scalingo, donc du temps de compute gâché et du temps perdu lors des code reviews, nous voulons nous assurer que le projet est buildable avant qu'il n'arrive sur le dépôt github.

Cette PR ajoute donc la dépendance de développement [Husky](https://typicode.github.io/husky/), qui permet d'installer des hooks git locaux lors d'un `npm install`, grâce au script spécial `prepare` de npm. 

Deux hooks ont été écrits pour l'instant: 
- Avant un commit, le code est bien présenté via `prettier` 
- Avant un push, le code est built en local.