### PR TITLE
Le texte "Cette exploitation possède cette parcelle" n'apparait plus sur des parcelles non attribuées

### DIFF
--- a/inertia/components/map/VisualisationMap.tsx
+++ b/inertia/components/map/VisualisationMap.tsx
@@ -257,7 +257,7 @@ const VisualisationMap = forwardRef<
             isUnavailable,
             isBio,
             editMode,
-            exploitation?.id === selectedExploitation?.id
+            selectedExploitation?.id !== undefined && exploitation?.id === selectedExploitation?.id
           )
 
           parcellePopupRef.current


### PR DESCRIPTION
Ce texte apparaissait sur des parcelles non-attribuées.
<img width="365" height="313" alt="image" src="https://github.com/user-attachments/assets/efdf0194-1388-459e-88bb-142dc3e4b713" />

Quand aucune exploitation n'était sélectionnée, la condition d'affichage du texte revenait à tester `undefined === undefined`. La condition a été corrigée pour tester si une exploitation est sélectionnée.

Closes #335 