### PR TITLE
Correction de la classe d'icône info

### DIFF
--- a/inertia/components/aac-id/aac-captages.tsx
+++ b/inertia/components/aac-id/aac-captages.tsx
@@ -116,7 +116,7 @@ export default function AacCaptages({ installations }: AacCaptagesProps) {
                 additionalInfos={{
                   ...(installation.prioritaire === true && {
                     message: 'Prioritaire',
-                    iconId: 'fr-icon-infos-fill',
+                    iconId: 'fr-icon-info-fill',
                   }),
                   ...(installation.etat && {
                     alert: {


### PR DESCRIPTION
Cette PR remplace la classe `fr-icon-infos-fill` par de `fr-icon-info-fill` et corrige ainsi l'affichage de l'icône.