### PR TITLE
Refonte du design de la page des AACs

### DIFF
--- a/app/controllers/aac_controller.ts
+++ b/app/controllers/aac_controller.ts
@@ -10,9 +10,14 @@ export default class AacController {
   constructor(public aacService: AacService) {}
 
   async index({ request, inertia }: HttpContext) {
-    const page = Math.max(1, Number.parseInt(request.input('aacPage', '1'), 10) || 1)
-    const recherche = request.input('aacRecherche') || undefined
-    const commune = request.input('aacCommune') || undefined
+    // Backward compatibility for legacy bookmarks/links using page/recherche/commune.
+    const pageInput = request.input('aacPage') || request.input('page') || '1'
+    const rechercheInput = request.input('aacRecherche') ?? request.input('recherche')
+    const communeInput = request.input('aacCommune') ?? request.input('commune')
+
+    const page = Math.max(1, Number.parseInt(pageInput, 10) || 1)
+    const recherche = rechercheInput || undefined
+    const commune = communeInput || undefined
 
     const { data, total } = await this.aacService.getAll(page, PER_PAGE, recherche, commune)
     const lastPage = Math.max(1, Math.ceil(total / PER_PAGE))

--- a/inertia/components/aacs/aacs-left-sidebar.tsx
+++ b/inertia/components/aacs/aacs-left-sidebar.tsx
@@ -40,7 +40,10 @@ export default function AACsLeftSidebar({ aacs, queryString, meta }: AACsLeftSid
     <div>
       <div className="fr-p-1w">
         <div className="flex flex-col gap-5">
-          <AacsSearch queryString={queryString} />
+          <AacsSearch
+            queryString={queryString}
+            reloadOnly={['aacs', 'aacMeta', 'aacQueryString']}
+          />
 
           {aacs.length === 0 ? (
             <EmptyPlaceholder

--- a/inertia/components/aacs/aacs-search.tsx
+++ b/inertia/components/aacs/aacs-search.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useState } from 'react'
+import { ChangeEvent, useEffect, useMemo, useState } from 'react'
 
 import { debounce } from 'lodash-es'
 import { router } from '@inertiajs/react'
@@ -13,31 +13,52 @@ export type AacsSearchProps = {
     aacCommune: string
     aacPage: string
   }
+  reloadOnly: string[]
 }
 
-const handleSearch = debounce((value: string) => {
-  router.reload({
-    only: ['aacs', 'aacMeta', 'aacQueryString'],
-    data: { aacRecherche: value, aacPage: '1' },
-    replace: true,
-  })
-}, 300)
-
-const handleCommuneFilter = debounce((value: string) => {
-  router.reload({
-    only: ['aacs', 'aacMeta', 'aacQueryString'],
-    data: { aacCommune: value, aacPage: '1' },
-    replace: true,
-  })
-}, 300)
-
-export default function AacsSearch({ queryString }: AacsSearchProps) {
+export default function AacsSearch({ queryString, reloadOnly }: AacsSearchProps) {
   const [isFiltersVisible, setIsFiltersVisible] = useState(false)
+  const [searchValue, setSearchValue] = useState(queryString?.aacRecherche || '')
   const [communeFilter, setCommuneFilter] = useState(queryString?.aacCommune || '')
+
+  const handleSearch = useMemo(
+    () =>
+      debounce((value: string) => {
+        router.reload({
+          only: reloadOnly,
+          data: { aacRecherche: value, aacPage: '1' },
+          replace: true,
+        })
+      }, 300),
+    [reloadOnly]
+  )
+
+  const handleCommuneFilter = useMemo(
+    () =>
+      debounce((value: string) => {
+        router.reload({
+          only: reloadOnly,
+          data: { aacCommune: value, aacPage: '1' },
+          replace: true,
+        })
+      }, 300),
+    [reloadOnly]
+  )
+
+  useEffect(() => {
+    setSearchValue(queryString?.aacRecherche || '')
+  }, [queryString?.aacRecherche])
 
   useEffect(() => {
     setCommuneFilter(queryString?.aacCommune || '')
   }, [queryString?.aacCommune])
+
+  useEffect(() => {
+    return () => {
+      handleSearch.cancel()
+      handleCommuneFilter.cancel()
+    }
+  }, [handleSearch, handleCommuneFilter])
 
   return (
     <div className="flex flex-col gap-4">
@@ -50,8 +71,11 @@ export default function AacsSearch({ queryString }: AacsSearchProps) {
               id={id}
               type={type}
               placeholder="Rechercher par code ou nom d'AAC"
-              defaultValue={queryString?.aacRecherche || ''}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => handleSearch(e.target.value)}
+              value={searchValue}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                setSearchValue(e.target.value)
+                handleSearch(e.target.value)
+              }}
             />
           )}
         />
@@ -96,9 +120,10 @@ export default function AacsSearch({ queryString }: AacsSearchProps) {
                 priority="tertiary no outline"
                 size="small"
                 onClick={() => {
+                  handleCommuneFilter.cancel()
                   setCommuneFilter('')
                   router.reload({
-                    only: ['aacs', 'aacMeta', 'aacQueryString'],
+                    only: reloadOnly,
                     data: { aacCommune: '', aacPage: '1' },
                     replace: true,
                   })

--- a/inertia/components/search-autocomplete.tsx
+++ b/inertia/components/search-autocomplete.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 
+import { debounce } from 'lodash-es'
 import { fr } from '@codegouvfr/react-dsfr'
 import { Input } from '@codegouvfr/react-dsfr/Input'
 
@@ -44,7 +45,14 @@ export default function SearchAutocomplete<T>(props: SearchAutocompleteProps<T>)
   const [filteredOptions, setFilteredOptions] = useState<T[]>([])
   const containerRef = useRef<HTMLDivElement>(null)
   const isUserTypingRef = useRef(false)
-
+  // Créer un debounce pour réinitialiser le flag après que l'utilisateur arrête de taper
+  const resetUserTypingFlag = useMemo(
+    () =>
+      debounce(() => {
+        isUserTypingRef.current = false
+      }, 500),
+    []
+  )
   // Mise à jour de l’input lorsque la valeur change depuis un autre composant
   useEffect(() => {
     if (!isUserTypingRef.current) {
@@ -75,12 +83,19 @@ export default function SearchAutocomplete<T>(props: SearchAutocompleteProps<T>)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
+  useEffect(() => {
+    return () => {
+      resetUserTypingFlag.cancel()
+    }
+  }, [resetUserTypingFlag])
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value
     isUserTypingRef.current = true
     setInputValue(newValue)
     setIsOpen(true)
     onInputChange?.(newValue)
+    resetUserTypingFlag()
   }
 
   const handleOptionClick = (option: T) => {

--- a/inertia/pages/aac/index.tsx
+++ b/inertia/pages/aac/index.tsx
@@ -28,7 +28,7 @@ export default function AacIndex({
       </div>
 
       <div className="fr-container flex flex-col gap-4 fr-mt-4w fr-mb-8w">
-        <AacsSearch queryString={queryString} />
+        <AacsSearch queryString={queryString} reloadOnly={['aacs', 'meta', 'queryString']} />
 
         {aacs.length === 0 ? (
           <EmptyPlaceholder
@@ -72,7 +72,7 @@ export default function AacIndex({
                   defaultPage={meta.currentPage}
                   getPageLinkProps={(pageNumber) => {
                     const params = new URLSearchParams(queryString)
-                    params.set('page', String(pageNumber))
+                    params.set('aacPage', String(pageNumber))
                     return { href: `?${params.toString()}` }
                   }}
                 />


### PR DESCRIPTION
Cette pull request propose une refonte de la page des AAC afin d’améliorer l’expérience utilisateur en apportant de la cohérence dans le listing des AACs, ainsi que dans la recherche et de filtrage.

Elle introduit un composant dédié pour centraliser la logique, simplifie le code existant et améliore la cohérence de l’interface ainsi que la gestion des cas sans résultat.

### **AVANT**
<img width="1330" height="1288" alt="Capture d’écran 2026-03-20 à 12 00 50" src="https://github.com/user-attachments/assets/ce8876e3-fd87-49bd-b972-1977eb3a46de" />

### **APRÈS**
<img width="1291" height="1295" alt="Capture d’écran 2026-03-20 à 11 59 45" src="https://github.com/user-attachments/assets/7ddb5d84-12b1-4fd6-a5fb-389701bf4cca" />
