### PR TITLE
Amélioration du responsive dans les sections avec répartitions

### DIFF
--- a/inertia/components/aac-id/aac-communes-repartition.tsx
+++ b/inertia/components/aac-id/aac-communes-repartition.tsx
@@ -81,12 +81,12 @@ export default function AacCommunesRepartition({ communes }: AacCommunesRepartit
 
   return (
     <div className="flex w-full flex-wrap items-center gap-2">
-      <div className="min-h-[200px] h-full min-w-[300px] flex-[1_1_250px] flex justify-center items-center">
+      <div className="min-h-[200px] h-full min-w-0 sm:min-w-[300px] flex-[1_1_250px] flex justify-center items-center">
         <Doughnut chartItems={communesChartItems} unit="hectares" hideLegend />
       </div>
-      <div className="min-w-[300px] flex-1">
+      <div className="min-w-0 sm:min-w-[300px] flex-1">
         {communeProgressBarsItems.map((item) => (
-          <div key={item.label} className="w-full">
+          <div key={item.key} className="w-full">
             <LabeledProgressBar
               label={item.label}
               size="sm"

--- a/inertia/components/aac-id/aac-cultures-repartition.tsx
+++ b/inertia/components/aac-id/aac-cultures-repartition.tsx
@@ -97,7 +97,7 @@ export default function AacCulturesRepartition({
       />
 
       <div className="flex w-full flex-wrap items-center gap-2">
-        <div className="min-w-[300px] flex-1">
+        <div className="min-w-0 sm:min-w-[300px] flex-1">
           {cultureItems.map((item) => (
             <div key={item.label} className="w-full">
               <LabeledProgressBar
@@ -112,7 +112,7 @@ export default function AacCulturesRepartition({
             </div>
           ))}
         </div>
-        <div className="min-h-[200px] h-full min-w-[300px] flex-[1_1_250px] flex justify-center items-center">
+        <div className="min-h-[200px] h-full min-w-0 sm:min-w-[300px] flex-[1_1_250px] flex justify-center items-center">
           <Doughnut chartItems={cultureItems} unit="hectares" hideLegend />
         </div>
       </div>

--- a/inertia/components/aac-id/aac-territoire-section.tsx
+++ b/inertia/components/aac-id/aac-territoire-section.tsx
@@ -1,7 +1,3 @@
-import { useMemo } from 'react'
-
-import { brightStringToColor } from '~/functions/colors'
-
 import SectionCard from '~/ui/SectionCard'
 import ResumeCard from '~/ui/ResumeCard'
 import SmallSection from '~/ui/SmallSection'

--- a/inertia/ui/Charts/Doughnut/index.tsx
+++ b/inertia/ui/Charts/Doughnut/index.tsx
@@ -31,7 +31,6 @@ export default function Doughnut({
 
   const options = {
     maintainAspectRatio: false,
-    aspectRatio: 1,
     responsive: true,
     plugins: {
       legend: {


### PR DESCRIPTION
Cette PR modifie le comportement des sections comprenant des répartitions (dougnut + barres de progression).
Ces sections vont être utilisées dans des composants moins larges que la page d'une AAC et avaient besoin d'être adaptés en amont.

### **Avant**
<img width="355" height="1144" alt="Capture d’écran 2026-03-27 à 12 25 06" src="https://github.com/user-attachments/assets/8b0ea636-0888-4af6-968b-812103e02c6f" />

### **Après**
<img width="414" height="882" alt="Capture d’écran 2026-03-27 à 12 24 52" src="https://github.com/user-attachments/assets/f621fcad-d693-47c0-b3ad-503cc966d6aa" />
