### PR TITLE
Ajout de nouvelles couches sur la carte de visualisation

### DIFF
--- a/inertia/components/map-layer-filters.tsx
+++ b/inertia/components/map-layer-filters.tsx
@@ -9,12 +9,14 @@ export default function MapLayerFilters({
   showPpr = false,
   showCommunes = false,
   showBioOnly = false,
+  showSage = false,
   setShowParcelles = (_update) => {},
   setShowAac = (_update) => {},
   setShowPpe = (_update) => {},
   setShowPpr = (_update) => {},
   setShowCommunes = (_update) => {},
   setShowBioOnly = (_update) => {},
+  setShowSage = (_update) => {},
   canSwitchToBioOnly = true,
 }: {
   showParcelles?: boolean
@@ -23,12 +25,14 @@ export default function MapLayerFilters({
   showPpr?: boolean
   showCommunes?: boolean
   showBioOnly?: boolean
+  showSage?: boolean
   setShowParcelles?: Dispatch<SetStateAction<boolean>>
   setShowAac?: Dispatch<SetStateAction<boolean>>
   setShowPpe?: Dispatch<SetStateAction<boolean>>
   setShowPpr?: Dispatch<SetStateAction<boolean>>
   setShowCommunes?: Dispatch<SetStateAction<boolean>>
   setShowBioOnly?: Dispatch<SetStateAction<boolean>>
+  setShowSage?: Dispatch<SetStateAction<boolean>>
   canSwitchToBioOnly?: boolean
 }) {
   return (
@@ -61,13 +65,19 @@ export default function MapLayerFilters({
         onChange={() => setShowPpr((prev) => !prev)}
       />
       <LegendItem
+        label="SAGE"
+        hint="Schéma d'Aménagement et de Gestion des Eaux"
+        color="bg-green-600"
+        checked={showSage}
+        onChange={() => setShowSage((prev) => !prev)}
+      />
+      <LegendItem
         label="Délimitations des communes"
         checked={showCommunes}
         onChange={() => setShowCommunes((prev) => !prev)}
       />
       <LegendItem
         label="Parcelles bio uniquement"
-        hint="Disponible pour millésime 2024 uniquement"
         checked={showBioOnly}
         disabled={!showParcelles || !canSwitchToBioOnly}
         onChange={() => setShowBioOnly((prev) => !prev)}

--- a/inertia/components/map/VisualisationMap.tsx
+++ b/inertia/components/map/VisualisationMap.tsx
@@ -22,6 +22,8 @@ import {
   getPpeLayer,
   getPprSource,
   getPprLayer,
+  getSageSource,
+  getSageLayer,
 } from './styles/zonage'
 
 import { renderPopupParcelle } from './popup-parcelle'
@@ -86,6 +88,7 @@ const VisualisationMap = forwardRef<
     showCommunes?: boolean
     showBioOnly?: boolean
     visibleCultures?: string[]
+    showSage?: boolean
     style?: string
   }
 >(
@@ -112,6 +115,7 @@ const VisualisationMap = forwardRef<
       showCommunes = false,
       showBioOnly = false,
       visibleCultures = [],
+      showSage = false,
       style = 'vector',
     },
     ref
@@ -129,48 +133,25 @@ const VisualisationMap = forwardRef<
     const currentParcelleIdRef = useRef<string | null>(null)
     const currentStyleRef = useRef<string>('vector')
     const previousVisibleCulturesRef = useRef<string[]>([])
+    const showBioOnlyRef = useRef(false)
 
-    // Synchroniser la ref avec les props
+    // Synchroniser les refs avec les props
     useEffect(() => {
       previousVisibleCulturesRef.current = visibleCultures
     }, [visibleCultures])
 
+    useEffect(() => {
+      showBioOnlyRef.current = showBioOnly
+    }, [showBioOnly])
+
     // Fonction pour filtrer les parcelles par code culture
-    const updateCultureFilter = useCallback(
-      (cultureCodes: string[]) => {
-        if (!mapRef.current) return
+    const updateCultureFilter = useCallback((cultureCodes: string[]) => {
+      if (!mapRef.current) return
 
-        const map = mapRef.current
+      const map = mapRef.current
 
-        if (cultureCodes.length === 0) {
-          // Masquer tout avec un filtre qui ne match jamais
-          const hideFilter: maplibre.FilterSpecification = ['==', ['get', 'id_parcel'], '']
-          ;[
-            'parcelles-fill',
-            'parcelles-outline',
-            'parcellesbio-fill',
-            'parcellesbio-outline',
-          ].forEach((layerId) => {
-            if (map.getLayer(layerId)) {
-              map.setFilter(layerId, hideFilter)
-            }
-          })
-          return
-        }
-
-        // Convertir les codes en nombres
-        const codesAsNumbers = cultureCodes.map((code) => parseInt(code, 10))
-
-        // Créer le filtre selon le millésime
-        let filter: maplibre.FilterSpecification
-        if (millesime === '2024') {
-          // Millésime 2024 : 'code_group'
-          filter = ['in', ['to-number', ['get', 'code_group']], ['literal', codesAsNumbers]]
-        } else {
-          // Millésime 2023 : 'CODE_GROUP'
-          filter = ['in', ['to-number', ['get', 'CODE_GROUP']], ['literal', codesAsNumbers]]
-        }
-
+      if (cultureCodes.length === 0) {
+        const hideFilter: maplibre.FilterSpecification = ['==', ['get', 'id_parcel'], '']
         ;[
           'parcelles-fill',
           'parcelles-outline',
@@ -178,12 +159,29 @@ const VisualisationMap = forwardRef<
           'parcellesbio-outline',
         ].forEach((layerId) => {
           if (map.getLayer(layerId)) {
-            map.setFilter(layerId, filter)
+            map.setFilter(layerId, hideFilter)
           }
         })
-      },
-      [millesime]
-    )
+        return
+      }
+
+      // Convertir les codes en nombres
+      const codesAsNumbers = cultureCodes.map((code) => parseInt(code, 10))
+
+      const filter: maplibre.FilterSpecification = [
+        'in',
+        ['to-number', ['get', 'code_group']],
+        ['literal', codesAsNumbers],
+      ]
+
+      ;['parcelles-fill', 'parcelles-outline', 'parcellesbio-fill', 'parcellesbio-outline'].forEach(
+        (layerId) => {
+          if (map.getLayer(layerId)) {
+            map.setFilter(layerId, filter)
+          }
+        }
+      )
+    }, [])
 
     useImperativeHandle(ref, () => ({
       centerOnExploitation: (exploitation: ExploitationJson) => {
@@ -229,10 +227,10 @@ const VisualisationMap = forwardRef<
 
         const props = e.features?.[0]?.properties
 
-        // Le millésime 2024 utilise des minuscules, celui de 2023 des majuscules
-        const cultureCode = props?.code_cultu ?? props?.CODE_CULTU
-        const surfParc = props?.surf_parc ?? props?.SURF_PARC
-        const id = props?.id_parcel ?? props?.ID_PARCEL
+        // Tous les millésimes utilisent désormais les propriétés en minuscules
+        const cultureCode = props?.code_cultu
+        const surfParc = props?.surf_parc
+        const id = props?.id_parcel
         const isUnavailable = unavailableParcelleIds.includes(id)
 
         const comment = parcelleCommentMap.get(id)
@@ -308,7 +306,7 @@ const VisualisationMap = forwardRef<
         }
 
         const feature = e.features?.[0]
-        const id = feature?.properties?.['id_parcel'] || feature?.properties?.['ID_PARCEL']
+        const id = feature?.properties?.['id_parcel']
 
         if (feature?.properties && !unavailableParcelleIds.includes(id)) {
           onParcelleClick(feature)
@@ -353,6 +351,10 @@ const VisualisationMap = forwardRef<
           map.addSource('ppr', getPprSource({ pmtilesUrl }))
         }
 
+        if (!map.getSource('sage')) {
+          map.addSource('sage', getSageSource({ pmtilesUrl }))
+        }
+
         const addLayers = (
           layers: Array<{ id: string; [key: string]: any }>,
           beforeId?: string
@@ -378,6 +380,7 @@ const VisualisationMap = forwardRef<
         addLayers(getPpeLayer(), beforeId)
         addLayers(getAacLayer(), beforeId)
         addLayers(getCommunesLayer(), beforeId)
+        addLayers(getSageLayer(), beforeId)
         addLayers(getParcellesLayers(), beforeId)
 
         setIsMapLoading(false)
@@ -592,11 +595,13 @@ const VisualisationMap = forwardRef<
         addSourceIfMissing('aac', getAacSource({ pmtilesUrl }))
         addSourceIfMissing('ppe', getPpeSource({ pmtilesUrl }))
         addSourceIfMissing('ppr', getPprSource({ pmtilesUrl }))
+        addSourceIfMissing('sage', getSageSource({ pmtilesUrl }))
 
         addLayersIfMissing(getPprLayer())
         addLayersIfMissing(getPpeLayer())
         addLayersIfMissing(getAacLayer())
         addLayersIfMissing(getCommunesLayer())
+        addLayersIfMissing(getSageLayer())
         addLayersIfMissing(getParcellesLayers())
 
         // Appliquer immédiatement la visibilité des layers selon l'état des checkboxes
@@ -605,6 +610,7 @@ const VisualisationMap = forwardRef<
           { layers: ['ppe-fill', 'ppe-outline'], visible: showPpe },
           { layers: ['aac-fill', 'aac-outline'], visible: showAac },
           { layers: ['communes-outline'], visible: showCommunes },
+          { layers: ['sage-fill', 'sage-outline'], visible: showSage },
           { layers: ['parcelles-fill', 'parcelles-outline'], visible: showParcelles },
         ]
 
@@ -620,57 +626,79 @@ const VisualisationMap = forwardRef<
       })
 
       currentStyleRef.current = style
-    }, [style, showParcelles, showAac, showPpe, showPpr, showCommunes, updateCultureFilter])
+    }, [
+      style,
+      showParcelles,
+      showAac,
+      showPpe,
+      showPpr,
+      showCommunes,
+      showSage,
+      updateCultureFilter,
+    ])
 
     useEffect(() => {
-      if (!mapRef.current) {
-        return
-      }
+      if (!mapRef.current) return
 
       const map = mapRef.current
 
-      if (!map.isStyleLoaded()) {
-        return
+      const applyBioVisibility = () => {
+        if (showBioOnly) {
+          if (map.getLayer('parcelles-fill')) {
+            map.setLayoutProperty('parcelles-fill', 'visibility', 'none')
+          }
+
+          if (map.getLayer('parcelles-outline')) {
+            map.setLayoutProperty('parcelles-outline', 'visibility', 'none')
+          }
+
+          if (map.getLayer('parcellesbio-fill')) {
+            map.setPaintProperty('parcellesbio-fill', 'fill-opacity', [
+              'case',
+              ['boolean', ['feature-state', 'unavailable'], false],
+              0.3,
+              ['boolean', ['feature-state', 'highlighted'], false],
+              0.7,
+              0.5,
+            ])
+          }
+
+          if (map.getLayer('parcellesbio-outline')) {
+            map.setPaintProperty('parcellesbio-outline', 'line-opacity', 1)
+          }
+        } else {
+          if (map.getLayer('parcelles-fill')) {
+            map.setLayoutProperty(
+              'parcelles-fill',
+              'visibility',
+              showParcelles ? 'visible' : 'none'
+            )
+          }
+
+          if (map.getLayer('parcelles-outline')) {
+            map.setLayoutProperty(
+              'parcelles-outline',
+              'visibility',
+              showParcelles ? 'visible' : 'none'
+            )
+          }
+
+          if (map.getLayer('parcellesbio-fill')) {
+            map.setPaintProperty('parcellesbio-fill', 'fill-opacity', 0)
+          }
+
+          if (map.getLayer('parcellesbio-outline')) {
+            map.setPaintProperty('parcellesbio-outline', 'line-opacity', 0)
+          }
+        }
       }
 
-      if (showBioOnly) {
-        // Mode bio uniquement : rendre les parcelles bio opaques
-        if (map.getLayer('parcelles-fill')) {
-          map.setLayoutProperty('parcelles-fill', 'visibility', 'none')
-        }
-        if (map.getLayer('parcelles-outline')) {
-          map.setLayoutProperty('parcelles-outline', 'visibility', 'none')
-        }
-        if (map.getLayer('parcellesbio-fill')) {
-          map.setPaintProperty('parcellesbio-fill', 'fill-opacity', [
-            'case',
-            ['boolean', ['feature-state', 'unavailable'], false],
-            0.3,
-            ['boolean', ['feature-state', 'highlighted'], false],
-            0.7,
-            0.5,
-          ])
-        }
-        if (map.getLayer('parcellesbio-outline')) {
-          map.setPaintProperty('parcellesbio-outline', 'line-opacity', 1)
-        }
+      if (map.isStyleLoaded()) {
+        applyBioVisibility()
       } else {
-        // Mode normal : parcelles visibles, bio transparent pour détection uniquement
-        if (map.getLayer('parcelles-fill')) {
-          map.setLayoutProperty('parcelles-fill', 'visibility', showParcelles ? 'visible' : 'none')
-        }
-        if (map.getLayer('parcelles-outline')) {
-          map.setLayoutProperty(
-            'parcelles-outline',
-            'visibility',
-            showParcelles ? 'visible' : 'none'
-          )
-        }
-        if (map.getLayer('parcellesbio-fill')) {
-          map.setPaintProperty('parcellesbio-fill', 'fill-opacity', 0)
-        }
-        if (map.getLayer('parcellesbio-outline')) {
-          map.setPaintProperty('parcellesbio-outline', 'line-opacity', 0)
+        map.once('styledata', applyBioVisibility)
+        return () => {
+          map.off('styledata', applyBioVisibility)
         }
       }
     }, [showBioOnly, showParcelles])
@@ -719,8 +747,27 @@ const VisualisationMap = forwardRef<
           const currentCultures = previousVisibleCulturesRef.current
           updateCultureFilter(currentCultures)
 
+          // Réappliquer la visibilité bio si le mode est actif
+          if (showBioOnlyRef.current) {
+            if (map.getLayer('parcellesbio-fill')) {
+              map.setPaintProperty('parcellesbio-fill', 'fill-opacity', [
+                'case',
+                ['boolean', ['feature-state', 'unavailable'], false],
+                0.3,
+                ['boolean', ['feature-state', 'highlighted'], false],
+                0.7,
+                0.5,
+              ])
+            }
+
+            if (map.getLayer('parcellesbio-outline')) {
+              map.setPaintProperty('parcellesbio-outline', 'line-opacity', 1)
+            }
+          }
+
           // Réappliquer le highlight des parcelles sélectionnées
           let parcelleIds: string[] = []
+
           if (editMode) {
             parcelleIds = formParcelleIds
           } else if (selectedParcelle && selectedParcelle.year.toString() === millesime) {
@@ -794,7 +841,8 @@ const VisualisationMap = forwardRef<
         { layers: ['ppe-fill', 'ppe-outline'], visible: showPpe },
         { layers: ['aac-fill', 'aac-outline'], visible: showAac },
         { layers: ['communes-outline'], visible: showCommunes },
-        { layers: ['parcelles-fill', 'parcelles-outline'], visible: showParcelles },
+        { layers: ['sage-fill', 'sage-outline'], visible: showSage },
+        { layers: ['parcelles-fill', 'parcelles-outline'], visible: showParcelles && !showBioOnly },
       ]
 
       // Application de la visibilité pour chaque groupe de layers
@@ -805,7 +853,7 @@ const VisualisationMap = forwardRef<
           }
         })
       })
-    }, [showParcelles, showAac, showPpe, showPpr, showCommunes])
+    }, [showParcelles, showAac, showPpe, showPpr, showCommunes, showSage, showBioOnly])
 
     // Mise à jour du filtre quand visibleCultures change
     useEffect(() => {

--- a/inertia/components/map/VisualisationMap.tsx
+++ b/inertia/components/map/VisualisationMap.tsx
@@ -227,7 +227,6 @@ const VisualisationMap = forwardRef<
 
         const props = e.features?.[0]?.properties
 
-        // Tous les millésimes utilisent désormais les propriétés en minuscules
         const cultureCode = props?.code_cultu
         const surfParc = props?.surf_parc
         const id = props?.id_parcel

--- a/inertia/components/map/styles/parcelles.tsx
+++ b/inertia/components/map/styles/parcelles.tsx
@@ -11,7 +11,7 @@ const selectedZoomedOutLineWidth = 2
 const selectedZoomedInLineWidth = 4
 
 export const getParcellesLayers = (): LayerSpecification[] => {
-  const colorMatch: any[] = ['match', ['coalesce', ['get', 'code_group'], ['get', 'CODE_GROUP']]]
+  const colorMatch: any[] = ['match', ['get', 'code_group']]
 
   Object.entries(GROUPES_CULTURAUX).forEach(([code, info]) => {
     colorMatch.push(code.toString())
@@ -95,11 +95,6 @@ export const getParcellesLayers = (): LayerSpecification[] => {
   ]
 }
 
-const millesimeToIdKey: { [key: string]: string } = {
-  '2023': 'ID_PARCEL',
-  '2024': 'id_parcel',
-}
-
 export const getParcellesSource = ({
   pmtilesUrl,
   millesime,
@@ -110,6 +105,6 @@ export const getParcellesSource = ({
   return {
     type: 'vector',
     url: `pmtiles://${pmtilesUrl}/${millesime}/parcelles_france.pmtiles`,
-    promoteId: millesimeToIdKey[millesime] || 'id_parcel',
+    promoteId: 'id_parcel',
   }
 }

--- a/inertia/components/map/styles/zonage.tsx
+++ b/inertia/components/map/styles/zonage.tsx
@@ -36,7 +36,7 @@ export const getAacLayer = () => {
       'type': 'line',
       'source': 'aac',
       'source-layer': 'aac',
-      'minzoom': 10,
+      'minzoom': 8,
       'paint': {
         'line-color': '#009099',
         'line-width': 2,
@@ -67,7 +67,7 @@ export const getPpeLayer = () => {
       'type': 'line',
       'source': 'ppe',
       'source-layer': 'ppe',
-      'minzoom': 10,
+      'minzoom': 8,
       'layout': {
         visibility: 'none',
       },
@@ -101,12 +101,46 @@ export const getPprLayer = () => {
       'type': 'line',
       'source': 'ppr',
       'source-layer': 'ppr',
-      'minzoom': 10,
+      'minzoom': 8,
       'layout': {
         visibility: 'none',
       },
       'paint': {
         'line-color': 'darkorange',
+        'line-width': 2,
+        'line-opacity': 1,
+      },
+    },
+  ]
+}
+
+export const getSageLayer = () => {
+  return [
+    {
+      'id': 'sage-fill',
+      'type': 'fill',
+      'source': 'sage',
+      'source-layer': 'sage',
+      'minzoom': 12,
+      'layout': {
+        visibility: 'none',
+      },
+      'paint': {
+        'fill-color': '#4caf50',
+        'fill-opacity': 0.2,
+      },
+    },
+    {
+      'id': 'sage-outline',
+      'type': 'line',
+      'source': 'sage',
+      'source-layer': 'sage',
+      'minzoom': 8,
+      'layout': {
+        visibility: 'none',
+      },
+      'paint': {
+        'line-color': '#2e7d32',
         'line-width': 2,
         'line-opacity': 1,
       },
@@ -137,6 +171,17 @@ export const getPpeSource = ({
 }
 
 export const getPprSource = ({
+  pmtilesUrl,
+}: {
+  pmtilesUrl: string
+}): maplibregl.VectorSourceSpecification => {
+  return {
+    type: 'vector',
+    url: `pmtiles://${pmtilesUrl}/zonage.pmtiles`,
+  }
+}
+
+export const getSageSource = ({
   pmtilesUrl,
 }: {
   pmtilesUrl: string

--- a/inertia/components/visualisation-right-side-bar.tsx
+++ b/inertia/components/visualisation-right-side-bar.tsx
@@ -9,12 +9,14 @@ export default function VisualisationRightSideBar({
   showPpr = false,
   showCommunes = false,
   showBioOnly = false,
+  showSage = false,
   setShowParcelles = (_update: boolean | ((prev: boolean) => boolean)) => {},
   setShowAac = (_update: boolean | ((prev: boolean) => boolean)) => {},
   setShowPpe = (_update: boolean | ((prev: boolean) => boolean)) => {},
   setShowPpr = (_update: boolean | ((prev: boolean) => boolean)) => {},
   setShowCommunes = (_update: boolean | ((prev: boolean) => boolean)) => {},
   setShowBioOnly = (_update: boolean | ((prev: boolean) => boolean)) => {},
+  setShowSage = (_update: boolean | ((prev: boolean) => boolean)) => {},
   canSwitchToBioOnly = true,
   visibleCultures,
   onToggleCulture,
@@ -26,12 +28,14 @@ export default function VisualisationRightSideBar({
   showPpr?: boolean
   showCommunes?: boolean
   showBioOnly?: boolean
+  showSage?: boolean
   setShowParcelles?: (update: boolean | ((prev: boolean) => boolean)) => void
   setShowAac?: (update: boolean | ((prev: boolean) => boolean)) => void
   setShowPpe?: (update: boolean | ((prev: boolean) => boolean)) => void
   setShowPpr?: (update: boolean | ((prev: boolean) => boolean)) => void
   setShowCommunes?: (update: boolean | ((prev: boolean) => boolean)) => void
   setShowBioOnly?: (update: boolean | ((prev: boolean) => boolean)) => void
+  setShowSage?: (update: boolean | ((prev: boolean) => boolean)) => void
   canSwitchToBioOnly?: boolean
   visibleCultures?: string[]
   onToggleCulture?: (code: string) => void
@@ -58,6 +62,8 @@ export default function VisualisationRightSideBar({
           setShowCommunes={setShowCommunes}
           showBioOnly={showBioOnly}
           setShowBioOnly={setShowBioOnly}
+          showSage={showSage}
+          setShowSage={setShowSage}
           canSwitchToBioOnly={canSwitchToBioOnly}
         />
       </SmallSection>

--- a/inertia/pages/visualisation.tsx
+++ b/inertia/pages/visualisation.tsx
@@ -47,6 +47,7 @@ export default function VisualisationPage({
   const [showPpr, setShowPpr] = useState(false)
   const [showCommunes, setShowCommunes] = useState(false)
   const [showBioOnly, setShowBioOnly] = useState(false)
+  const [showSage, setShowSage] = useState(false)
   const mapRef = useRef<VisualisationMapRef>(null)
   const [visibleCultures, setVisibleCultures] = useState<string[]>(Object.keys(GROUPES_CULTURAUX))
   const [style, setStyle] = useState<string>('vector')
@@ -330,6 +331,9 @@ export default function VisualisationPage({
                 options={[
                   { value: '2024', label: 'RPG 2024' },
                   { value: '2023', label: 'RPG 2023' },
+                  { value: '2022', label: 'RPG 2022' },
+                  { value: '2021', label: 'RPG 2021' },
+                  { value: '2020', label: 'RPG 2020' },
                 ]}
               />
             </div>
@@ -354,6 +358,7 @@ export default function VisualisationPage({
             showPpr={showPpr}
             showCommunes={showCommunes}
             showBioOnly={showBioOnly}
+            showSage={showSage}
             ref={mapRef}
             visibleCultures={visibleCultures}
             style={style}
@@ -373,7 +378,9 @@ export default function VisualisationPage({
             setShowCommunes={() => setShowCommunes((prev) => !prev)}
             showBioOnly={showBioOnly}
             setShowBioOnly={() => setShowBioOnly((prev) => !prev)}
-            canSwitchToBioOnly={!editMode && millesime === '2024'}
+            showSage={showSage}
+            setShowSage={() => setShowSage((prev) => !prev)}
+            canSwitchToBioOnly={!editMode}
             visibleCultures={visibleCultures}
             onToggleCulture={toggleCulture}
             onToggleAllCultures={toggleAllCultures}


### PR DESCRIPTION
Cette PR apporte plusieurs modifications suite à la génération de nouvelles tuiles : 

- Ajout de l'affichage de la couche SAGE
- Ajout des RPG parcelles 2022, 2021 et 2020
- Ajout des parcelles en agriculture biologique pour tous les RPG

>[!warning]
> Ces modifications ne doivent pas être fusionnées à la branche `main` avant d'avoir mis à jour le fichier PMTiles du RPG 2023 qui utilisait des champs en lettres capitales