### PR TITLE
Filtrage des AACs dans la page visualisation

### DIFF
--- a/app/controllers/visualisation_controller.ts
+++ b/app/controllers/visualisation_controller.ts
@@ -51,7 +51,13 @@ export default class VisualisationController {
     let aacResultPromise: Promise<{ data: Record<string, unknown>[]; total: number }> | null = null
     const getAacResult = () => {
       if (!aacResultPromise) {
-        aacResultPromise = this.aacService.getAll(aacPage, AAC_PER_PAGE, aacRecherche, aacCommune)
+        aacResultPromise = this.aacService.getAll(
+          aacPage,
+          AAC_PER_PAGE,
+          aacRecherche,
+          aacCommune,
+          user.id
+        )
       }
       return aacResultPromise
     }

--- a/app/controllers/visualisation_controller.ts
+++ b/app/controllers/visualisation_controller.ts
@@ -34,6 +34,13 @@ export default class VisualisationController {
     }
 
     const user = auth.getUserOrFail()
+    const userTerritoireCodes: string[] = []
+
+    for (const territoire of user.territoires) {
+      if (territoire.code) {
+        userTerritoireCodes.push(territoire.code)
+      }
+    }
 
     this.eventLogger.logEvent({
       userId: user.id,
@@ -56,7 +63,7 @@ export default class VisualisationController {
           AAC_PER_PAGE,
           aacRecherche,
           aacCommune,
-          user.id
+          userTerritoireCodes
         )
       }
       return aacResultPromise
@@ -83,7 +90,7 @@ export default class VisualisationController {
         aacPage: String(aacPage),
       }),
       selectedAac: async () => {
-        if (!aacCode) return null
+        if (!aacCode || !userTerritoireCodes.includes(aacCode.toString())) return null
         const raw = await this.aacService.getByCode(aacCode)
         if (!raw) return null
         return AacDto.fromRawSummary(raw)

--- a/app/services/aac_service.ts
+++ b/app/services/aac_service.ts
@@ -1,7 +1,5 @@
 import { DuckDBInstance, DuckDBConnection } from '@duckdb/node-api'
 import env from '#start/env'
-import Territoire from '#models/territoire'
-import User from '#models/user'
 
 /** Escapes a value for safe embedding in a single-quoted SQL string literal. */
 function sqlEscape(value: string): string {
@@ -117,7 +115,7 @@ export class AacService {
     perPage: number,
     recherche?: string,
     commune?: string,
-    userId?: string
+    aacCodes?: string[]
   ): Promise<{ data: Record<string, unknown>[]; total: number }> {
     const conn = await getConnection()
     const path = getParquetPath()
@@ -144,31 +142,17 @@ export class AacService {
       filterParams.push(commune)
     }
 
-    if (userId) {
-      // Fetch territoires in which the given user is
-      const territoireCodeRows = await Territoire.query()
-        .whereHas('users', (usersQuery) => {
-          usersQuery.where(`${User.table}.id`, userId)
-        })
-        .select('code')
-
+    if (aacCodes && aacCodes.length > 0) {
       const placeholders: string[] = []
 
       // Build the param placeholders for the IN clause
-      for (const row of territoireCodeRows) {
-        if (row.code) {
-          placeholders.push(`$${paramIdx}`)
-          paramIdx++
-          filterParams.push(row.code)
-        }
+      for (const code of aacCodes) {
+        placeholders.push(`$${paramIdx}`)
+        paramIdx++
+        filterParams.push(code)
       }
 
-      if (placeholders.length > 0) {
-        conditions.push(`code IN (${placeholders.join(', ')})`)
-      } else {
-        // If there is no territoire, we add a bad filter to make the request return no results
-        conditions.push('1=0')
-      }
+      conditions.push(`code IN (${placeholders.join(', ')})`)
     }
 
     const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : ''

--- a/app/services/aac_service.ts
+++ b/app/services/aac_service.ts
@@ -1,5 +1,7 @@
 import { DuckDBInstance, DuckDBConnection } from '@duckdb/node-api'
 import env from '#start/env'
+import Territoire from '#models/territoire'
+import User from '#models/user'
 
 /** Escapes a value for safe embedding in a single-quoted SQL string literal. */
 function sqlEscape(value: string): string {
@@ -114,7 +116,8 @@ export class AacService {
     page: number,
     perPage: number,
     recherche?: string,
-    commune?: string
+    commune?: string,
+    userId?: string
   ): Promise<{ data: Record<string, unknown>[]; total: number }> {
     const conn = await getConnection()
     const path = getParquetPath()
@@ -139,6 +142,33 @@ export class AacService {
 
       paramIdx++
       filterParams.push(commune)
+    }
+
+    if (userId) {
+      // Fetch territoires in which the given user is
+      const territoireCodeRows = await Territoire.query()
+        .whereHas('users', (usersQuery) => {
+          usersQuery.where(`${User.table}.id`, userId)
+        })
+        .select('code')
+
+      const placeholders: string[] = []
+
+      // Build the param placeholders for the IN clause
+      for (const row of territoireCodeRows) {
+        if (row.code) {
+          placeholders.push(`$${paramIdx}`)
+          paramIdx++
+          filterParams.push(row.code)
+        }
+      }
+
+      if (placeholders.length > 0) {
+        conditions.push(`code IN (${placeholders.join(', ')})`)
+      } else {
+        // If there is no territoire, we add a bad filter to make the request return no results
+        conditions.push('1=0')
+      }
     }
 
     const where = conditions.length > 0 ? 'WHERE ' + conditions.join(' AND ') : ''


### PR DESCRIPTION
Cette PR ajoute le filtrage des AACs selon l'utilisateur connecté dans la page Visualisation. Au lieu d'afficher toutes les AACs existantes en base, seules les AACs auxquelles l'utilisateur connecté est affecté sont affichées.

<img width="1623" height="1026" alt="image" src="https://github.com/user-attachments/assets/a41b094f-f92c-403a-9db0-4e70747191f3" />


Closes #365 