### PR TITLE
Export du journal de bord d'une exploitation

### DIFF
--- a/app/controllers/exploitations_controller.ts
+++ b/app/controllers/exploitations_controller.ts
@@ -185,6 +185,7 @@ export default class ExploitationsController {
         .params([params.id])
         .make('log_entries.destroyTagForExploitation'),
       completeEntryLogUrl: router.builder().params([params.id]).make('log_entries.complete'),
+      exportLogEntriesUrl: router.builder().params([params.id]).make('log_entries.export'),
     })
   }
 

--- a/app/controllers/exploitations_controller.ts
+++ b/app/controllers/exploitations_controller.ts
@@ -262,7 +262,6 @@ export default class ExploitationsController {
       .where('id', params.id)
       .firstOrFail()
 
-    // Proof of concept, useless before the authorization rework
     if (await bouncer.with(ExploitationPolicy).denies('write', exploitation)) {
       return response.forbidden("Impossible de mettre à jour l'exploitation")
     }
@@ -309,7 +308,6 @@ export default class ExploitationsController {
       .where('id', params.id)
       .firstOrFail()
 
-    // Proof of concept, useless before the authorization rework
     if (await bouncer.with(ExploitationPolicy).denies('write', exploitation)) {
       return response.forbidden("Impossible de supprimer l'exploitation")
     }

--- a/app/controllers/log_entries_controller.ts
+++ b/app/controllers/log_entries_controller.ts
@@ -23,6 +23,7 @@ import { ExploitationService } from '#services/exploitation_service'
 import { LogEntryDto } from '../dto/log_entry_dto.js'
 import { ExploitationDto } from '../dto/exploitation_dto.js'
 import { LogEntryDocumentService } from '#services/log_entry_document_service'
+import { LogEntryCsvService } from '#services/log_entry_csv_service'
 
 // Définition centralisée des noms d'événements pour ce contrôleur
 const EVENTS = {
@@ -46,6 +47,7 @@ export default class LogEntriesController {
     public logEntryService: LogEntryService,
     public logEntryTagService: LogEntryTagService,
     public logEntryDocumentService: LogEntryDocumentService,
+    public logEntryCsvService: LogEntryCsvService,
     public eventLogger: EventLoggerService,
     public exploitationService: ExploitationService
   ) {}
@@ -89,6 +91,23 @@ export default class LogEntriesController {
         .make('log_entries.destroyTagForExploitation'),
       createEntryLogUrl: router.builder().params([exploitationId]).make('log_entries.create'),
     })
+  }
+
+  async exportCsv({ params, response }: HttpContext) {
+    const exploitationId = params.exploitationId
+    const exploitation = await Exploitation.findOrFail(exploitationId)
+
+    const entries = await this.logEntryService.getAllLogEntriesForExploitation(exploitationId)
+    const csv = this.logEntryCsvService.generateCsv(entries)
+
+    const safeName = exploitation.name.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 50)
+    const date = new Date().toISOString().slice(0, 10)
+    const filename = `journal-${safeName}-${date}.csv`
+
+    return response
+      .header('Content-Type', 'text/csv; charset=utf-8')
+      .header('Content-Disposition', `attachment; filename="${filename}"`)
+      .send(csv)
   }
 
   async get({ request, params, inertia, auth }: HttpContext) {

--- a/app/controllers/log_entries_controller.ts
+++ b/app/controllers/log_entries_controller.ts
@@ -24,6 +24,7 @@ import { LogEntryDto } from '../dto/log_entry_dto.js'
 import { ExploitationDto } from '../dto/exploitation_dto.js'
 import { LogEntryDocumentService } from '#services/log_entry_document_service'
 import { LogEntryCsvService } from '#services/log_entry_csv_service'
+import ExploitationPolicy from '#policies/exploitation_policy'
 
 // Définition centralisée des noms d'événements pour ce contrôleur
 const EVENTS = {
@@ -93,9 +94,13 @@ export default class LogEntriesController {
     })
   }
 
-  async exportCsv({ params, response }: HttpContext) {
+  async exportCsv({ bouncer, params, response }: HttpContext) {
     const exploitationId = params.exploitationId
     const exploitation = await Exploitation.findOrFail(exploitationId)
+
+    if (await bouncer.with(ExploitationPolicy).denies('write', exploitation)) {
+      return response.forbidden("Impossible d'exporter les données de l'exploitation")
+    }
 
     const entries = await this.logEntryService.getAllLogEntriesForExploitation(exploitationId)
     const csv = this.logEntryCsvService.generateCsv(entries)

--- a/app/services/log_entry_csv_service.ts
+++ b/app/services/log_entry_csv_service.ts
@@ -46,9 +46,12 @@ export class LogEntryCsvService {
   }
 
   private escapeField(value: string | null | undefined): string {
+    // Ensures the value is a string
     const str = value ?? ''
+    // Protect against CSV injection by prefixing dangerous characters with a single quote
+    const safeStr = /^\s*[=+\-@]/.test(str) ? `'${str}` : str
     // Wrap in double quotes and escape inner double quotes by doubling them
-    return `"${str.replace(/"/g, '""')}"`
+    return `"${safeStr.replace(/"/g, '""')}"`
   }
 
   private formatDate(date: DateTime | null | undefined): string | null {

--- a/app/services/log_entry_csv_service.ts
+++ b/app/services/log_entry_csv_service.ts
@@ -1,0 +1,63 @@
+import { DateTime } from 'luxon'
+import LogEntry from '#models/log_entry'
+
+const SEPARATOR = ';'
+const LINE_END = '\r\n'
+const BOM = '\uFEFF'
+
+const HEADERS = [
+  'Date',
+  'Titre',
+  'Notes',
+  'Auteur',
+  'Statut',
+  'Étiquettes',
+  'Créé le',
+  'Modifié le',
+]
+
+export class LogEntryCsvService {
+  /**
+   * Génère une chaîne CSV (avec BOM UTF-8) à partir d'une liste d'entrées de journal.
+   * Les relations author, tags et documents doivent être préchargées.
+   */
+  generateCsv(entries: LogEntry[]): string {
+    const rows = [
+      HEADERS.map((h) => this.escapeField(h)).join(SEPARATOR),
+      ...entries.map((entry) => this.buildRow(entry)),
+    ]
+
+    return BOM + rows.join(LINE_END)
+  }
+
+  private buildRow(entry: LogEntry): string {
+    const fields = [
+      this.formatDate(entry.date),
+      entry.title,
+      entry.notes,
+      entry.author?.fullName ?? entry.author?.email ?? null,
+      entry.isCompleted ? 'Effectuée' : 'Non effectuée',
+      entry.tags?.map((t) => t.name).join(' | ') ?? null,
+      this.formatDateTime(entry.createdAt),
+      this.formatDateTime(entry.updatedAt),
+    ]
+
+    return fields.map((f) => this.escapeField(f)).join(SEPARATOR)
+  }
+
+  private escapeField(value: string | null | undefined): string {
+    const str = value ?? ''
+    // Wrap in double quotes and escape inner double quotes by doubling them
+    return `"${str.replace(/"/g, '""')}"`
+  }
+
+  private formatDate(date: DateTime | null | undefined): string | null {
+    if (!date) return null
+    return date.toFormat('dd/MM/yyyy')
+  }
+
+  private formatDateTime(date: DateTime | null | undefined): string | null {
+    if (!date) return null
+    return date.toFormat('dd/MM/yyyy HH:mm')
+  }
+}

--- a/app/services/log_entry_service.ts
+++ b/app/services/log_entry_service.ts
@@ -23,6 +23,15 @@ export class LogEntryService {
     return logEntry
   }
 
+  async getAllLogEntriesForExploitation(exploitationId: string) {
+    return this.queryLogEntriesFromActiveExploitation()
+      .where('exploitationId', exploitationId)
+      .preload('author')
+      .preload('tags')
+      .preload('documents')
+      .orderBy('date', 'desc')
+  }
+
   async getLogForExploitation(exploitationId: string, page = 1, pageSize = 10) {
     return this.queryLogEntriesFromActiveExploitation()
       .where('exploitationId', exploitationId)

--- a/app/services/log_entry_service.ts
+++ b/app/services/log_entry_service.ts
@@ -28,7 +28,6 @@ export class LogEntryService {
       .where('exploitationId', exploitationId)
       .preload('author')
       .preload('tags')
-      .preload('documents')
       .orderBy('date', 'desc')
   }
 

--- a/inertia/components/exploitation-id/ExploitationActionCard.tsx
+++ b/inertia/components/exploitation-id/ExploitationActionCard.tsx
@@ -1,0 +1,73 @@
+import { ExploitationJson } from '../../../types/models'
+import { router } from '@inertiajs/react'
+import SmallSection from '~/ui/SmallSection'
+import { useState } from 'react'
+import DeleteAlert from '~/ui/DeleteAlert'
+import Alert from '@codegouvfr/react-dsfr/Alert'
+import Input from '@codegouvfr/react-dsfr/Input'
+import { createModal } from '@codegouvfr/react-dsfr/Modal'
+
+const deleteExploitationModal = createModal({
+  id: 'delete-exploitation-modal',
+  isOpenedByDefault: false,
+})
+
+export function ExploitationActionCard({
+  exploitation,
+  exportLogEntriesUrl,
+  deleteExploitationUrl,
+}: {
+  exploitation: ExploitationJson
+  exportLogEntriesUrl: string
+  deleteExploitationUrl: string
+}) {
+  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] = useState(true)
+
+  return (
+    <SmallSection title="Actions" priority="secondary" hasBorder>
+      <a
+        className="fr-btn fr-btn--secondary fr-icon-download-line fr-btn--icon-left fr-mb-2w"
+        href={exportLogEntriesUrl}
+      >
+        Exporter le journal de bord
+      </a>
+      <DeleteAlert
+        title="Supprimer l'exploitation"
+        description="Attention : cette action est irréversible !"
+        size="sm"
+        onDelete={deleteExploitationModal.open}
+      />
+      <deleteExploitationModal.Component
+        title=""
+        size="large"
+        buttons={[
+          { children: 'Annuler', doClosesModal: true },
+          {
+            children: "Supprimer l'exploitation",
+            disabled: isDeleteButtonDisabled,
+            onClick: () => {
+              router.delete(deleteExploitationUrl)
+            },
+          },
+        ]}
+      >
+        <Alert
+          severity="error"
+          title="Suppression d'une exploitation"
+          description="Vous êtes sur le point de supprimer cette exploitation. Cette action est irréversible et entraînera la suppression de toutes les données associées."
+        />
+        <div className="fr-mt-3w">
+          <Input
+            label={`Pour confirmer la suppression, veuillez taper "${exploitation.name}" :`}
+            nativeInputProps={{
+              placeholder: exploitation.name,
+              onChange: (e) => {
+                setIsDeleteButtonDisabled(e.currentTarget.value !== exploitation.name)
+              },
+            }}
+          />
+        </div>
+      </deleteExploitationModal.Component>
+    </SmallSection>
+  )
+}

--- a/inertia/pages/exploitations/id.tsx
+++ b/inertia/pages/exploitations/id.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react'
 import { InferPageProps } from '@adonisjs/inertia/types'
 import ExploitationsController from '#controllers/exploitations_controller'
-import { Head, router } from '@inertiajs/react'
+import { Head } from '@inertiajs/react'
 import Layout from '~/ui/layouts/layout'
 import { fr } from '@codegouvfr/react-dsfr'
 import { Button } from '@codegouvfr/react-dsfr/Button'
@@ -9,24 +8,17 @@ import Breadcrumb from '@codegouvfr/react-dsfr/Breadcrumb'
 import { ExploitationInformationCard } from '~/components/exploitation-id/ExploitationInformationCard'
 import { ExploitationAddressCard } from '~/components/exploitation-id/ExploitationAddressCard'
 import { ExploitationContactCard } from '~/components/exploitation-id/ExploitationContactCard'
-import DeleteAlert from '~/ui/DeleteAlert'
-import { createModal } from '@codegouvfr/react-dsfr/Modal'
-import Alert from '@codegouvfr/react-dsfr/Alert'
 import { ExploitationMainColumn } from '~/components/exploitation-id/ExploitationMainColumn'
-import Input from '@codegouvfr/react-dsfr/Input'
-import TruncatedText from '~/ui/TruncatedText'
 
-const deleteExploitationModal = createModal({
-  id: 'delete-exploitation-modal',
-  isOpenedByDefault: false,
-})
+import TruncatedText from '~/ui/TruncatedText'
+import { ExploitationActionCard } from '~/components/exploitation-id/ExploitationActionCard'
 
 export default function SingleExploitation({
   exploitation,
   deleteExploitationUrl,
   editExploitationUrl,
+  exportLogEntriesUrl,
 }: InferPageProps<ExploitationsController, 'get'>) {
-  const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] = useState(true)
   return (
     <Layout>
       <Head title={exploitation.name} />
@@ -78,43 +70,11 @@ export default function SingleExploitation({
               exploitation={exploitation}
               editExploitationUrl={editExploitationUrl}
             />
-            <DeleteAlert
-              title="Supprimer l'exploitation"
-              description="Attention : cette action est irréversible !"
-              size="sm"
-              onDelete={deleteExploitationModal.open}
+            <ExploitationActionCard
+              exploitation={exploitation}
+              exportLogEntriesUrl={exportLogEntriesUrl}
+              deleteExploitationUrl={deleteExploitationUrl}
             />
-            <deleteExploitationModal.Component
-              title=""
-              size="large"
-              buttons={[
-                { children: 'Annuler', doClosesModal: true },
-                {
-                  children: "Supprimer l'exploitation",
-                  disabled: isDeleteButtonDisabled,
-                  onClick: () => {
-                    router.delete(deleteExploitationUrl)
-                  },
-                },
-              ]}
-            >
-              <Alert
-                severity="error"
-                title="Suppression d'une exploitation"
-                description="Vous êtes sur le point de supprimer cette exploitation. Cette action est irréversible et entraînera la suppression de toutes les données associées."
-              />
-              <div className="fr-mt-3w">
-                <Input
-                  label={`Pour confirmer la suppression, veuillez taper "${exploitation.name}" :`}
-                  nativeInputProps={{
-                    placeholder: exploitation.name,
-                    onChange: (e) => {
-                      setIsDeleteButtonDisabled(e.currentTarget.value !== exploitation.name)
-                    },
-                  }}
-                />
-              </div>
-            </deleteExploitationModal.Component>
           </aside>
           <ExploitationMainColumn
             exploitationId={exploitation.id}

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -83,6 +83,10 @@ router
           .as('log_entries.index')
 
         router
+          .get('exploitations/:exploitationId/journal/export', [LogEntriesController, 'exportCsv'])
+          .as('log_entries.export')
+
+        router
           .get('exploitations/:exploitationId/journal/:logEntryId', [LogEntriesController, 'get'])
           .as('log_entries.get')
 

--- a/tests/unit/log_entry/log_entry_csv_service.spec.ts
+++ b/tests/unit/log_entry/log_entry_csv_service.spec.ts
@@ -1,0 +1,201 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { DateTime } from 'luxon'
+import { LogEntryCsvService } from '#services/log_entry_csv_service'
+import { LogEntryFactory } from '#database/factories/log_entry_factory'
+import { LogEntryTagFactory } from '#database/factories/log_entry_tag_factory'
+import { UserFactory } from '#database/factories/user_factory'
+import { ExploitationFactory } from '#database/factories/exploitation_factory'
+
+const BOM = '\uFEFF'
+
+/**
+ * Splits a CSV string into rows (strips BOM, splits on CRLF).
+ */
+function parseRows(csv: string): string[] {
+  return csv.replace(BOM, '').split('\r\n')
+}
+
+/**
+ * Naive field splitter — only use when no field contains a semicolon.
+ */
+function parseFields(row: string): string[] {
+  return row.split(';')
+}
+
+test.group('LogEntryCsvService', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('generates only the header row for an empty list', ({ assert }) => {
+    const csv = new LogEntryCsvService().generateCsv([])
+    const rows = parseRows(csv)
+
+    assert.lengthOf(rows, 1)
+    assert.include(rows[0], '"Date"')
+    assert.include(rows[0], '"Modifié le"')
+  })
+
+  test('output starts with UTF-8 BOM', async ({ assert }) => {
+    const entry = await LogEntryFactory.with('author').with('exploitation').create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const csv = new LogEntryCsvService().generateCsv([entry])
+
+    assert.isTrue(csv.startsWith(BOM))
+  })
+
+  test('generates one data row per entry', async ({ assert }) => {
+    const entries = await LogEntryFactory.with('author').with('exploitation').createMany(3)
+    for (const entry of entries) {
+      await entry.load('author')
+      await entry.load('tags')
+    }
+
+    const csv = new LogEntryCsvService().generateCsv(entries)
+
+    assert.lengthOf(parseRows(csv), 4) // 1 header + 3 data rows
+  })
+
+  test('sets status to "Effectuée" when isCompleted is true', async ({ assert }) => {
+    const entry = await LogEntryFactory.merge({ isCompleted: true, date: DateTime.now() })
+      .with('author')
+      .with('exploitation')
+      .create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const csv = new LogEntryCsvService().generateCsv([entry])
+
+    assert.include(csv, '"Effectuée"')
+  })
+
+  test('sets status to "Non effectuée" when isCompleted is false', async ({ assert }) => {
+    const entry = await LogEntryFactory.merge({ isCompleted: false })
+      .with('author')
+      .with('exploitation')
+      .create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const csv = new LogEntryCsvService().generateCsv([entry])
+
+    assert.include(csv, '"Non effectuée"')
+  })
+
+  test('uses author fullName when available', async ({ assert }) => {
+    const user = await UserFactory.merge({ fullName: 'Jean Dupont' }).create()
+    const entry = await LogEntryFactory.merge({ userId: user.id, notes: 'test notes', title: null })
+      .with('exploitation')
+      .create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const fields = parseFields(parseRows(new LogEntryCsvService().generateCsv([entry]))[1])
+
+    assert.equal(fields[3], '"Jean Dupont"')
+  })
+
+  test('falls back to email when fullName is null', async ({ assert }) => {
+    const user = await UserFactory.merge({ fullName: null, email: 'jean@example.com' }).create()
+    const entry = await LogEntryFactory.merge({ userId: user.id, notes: 'test notes', title: null })
+      .with('exploitation')
+      .create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const fields = parseFields(parseRows(new LogEntryCsvService().generateCsv([entry]))[1])
+
+    assert.equal(fields[3], '"jean@example.com"')
+  })
+
+  test('joins multiple tags with " | "', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const exploitation = await ExploitationFactory.create()
+    const [tag1, tag2] = await LogEntryTagFactory.merge({
+      userId: user.id,
+      exploitationId: exploitation.id,
+    }).createMany(2)
+    const entry = await LogEntryFactory.merge({
+      userId: user.id,
+      exploitationId: exploitation.id,
+    }).create()
+    await entry.related('tags').attach([tag1.id, tag2.id])
+    await entry.load('author')
+    await entry.load('tags')
+
+    const expectedTags = entry.tags.map((t) => t.name).join(' | ')
+    const csv = new LogEntryCsvService().generateCsv([entry])
+
+    assert.include(csv, `"${expectedTags}"`)
+  })
+
+  test('outputs an empty tags field when entry has no tags', async ({ assert }) => {
+    const entry = await LogEntryFactory.merge({ notes: 'test notes', title: null })
+      .with('author')
+      .with('exploitation')
+      .create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const fields = parseFields(parseRows(new LogEntryCsvService().generateCsv([entry]))[1])
+
+    assert.equal(fields[5], '""')
+  })
+
+  test('outputs an empty date field when date is null', async ({ assert }) => {
+    const entry = await LogEntryFactory.merge({ date: null, notes: 'test notes', title: null })
+      .with('author', 1, (f) => f.merge({ fullName: 'Author' }))
+      .with('exploitation')
+      .create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const fields = parseFields(parseRows(new LogEntryCsvService().generateCsv([entry]))[1])
+
+    assert.equal(fields[0], '""')
+  })
+
+  test('formats date as dd/MM/yyyy', async ({ assert }) => {
+    const entry = await LogEntryFactory.merge({
+      date: DateTime.fromISO('2025-03-15'),
+      notes: 'test notes',
+      title: null,
+    })
+      .with('author', 1, (f) => f.merge({ fullName: 'Author' }))
+      .with('exploitation')
+      .create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const fields = parseFields(parseRows(new LogEntryCsvService().generateCsv([entry]))[1])
+
+    assert.equal(fields[0], '"15/03/2025"')
+  })
+
+  test('prefixes CSV injection characters with a single quote', async ({ assert }) => {
+    const entry = await LogEntryFactory.merge({ notes: '=SUM(A1:B2)' })
+      .with('author')
+      .with('exploitation')
+      .create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const csv = new LogEntryCsvService().generateCsv([entry])
+
+    assert.include(csv, '"\'=SUM(A1:B2)"')
+  })
+
+  test('escapes double quotes by doubling them', async ({ assert }) => {
+    const entry = await LogEntryFactory.merge({ notes: 'He said "hello"' })
+      .with('author')
+      .with('exploitation')
+      .create()
+    await entry.load('author')
+    await entry.load('tags')
+
+    const csv = new LogEntryCsvService().generateCsv([entry])
+
+    assert.include(csv, '"He said ""hello"""')
+  })
+})


### PR DESCRIPTION
Cette PR ajoute la possibilité d'exporter les entrées du journal de bord d'une exploitation. Lors de la pression du bouton, un téléchargement de CSV se lance.

<img width="1250" height="1033" alt="image" src="https://github.com/user-attachments/assets/cb294f57-1d93-4b7e-90fb-5aabf68ec58d" />

Closes #150 
