### PR TITLE
Export des parcelles d'une exploitation en CSV

### DIFF
--- a/app/controllers/exploitations_controller.ts
+++ b/app/controllers/exploitations_controller.ts
@@ -18,6 +18,8 @@ import { EventLoggerService } from '#services/event_logger_service'
 import { ExploitationTagService } from '#services/exploitation_tag_service'
 import { ExploitationTagDto } from '../dto/exploitation_tag_dto.js'
 import { ParcelleService } from '#services/parcelle_service'
+import { ParcelleCsvService } from '#services/parcelle_csv_service'
+import Exploitation from '#models/exploitation'
 import ExploitationPolicy from '#policies/exploitation_policy'
 
 // Définition centralisée des noms d'événements pour ce contrôleur
@@ -42,7 +44,8 @@ export default class ExploitationsController {
     public logEntryService: LogEntryService,
     public logEntryTagService: LogEntryTagService,
     public eventLogger: EventLoggerService,
-    public parcelleService: ParcelleService
+    public parcelleService: ParcelleService,
+    public parcelleCsvService: ParcelleCsvService
   ) {}
 
   async index({ request, inertia, auth }: HttpContext) {
@@ -186,6 +189,7 @@ export default class ExploitationsController {
         .make('log_entries.destroyTagForExploitation'),
       completeEntryLogUrl: router.builder().params([params.id]).make('log_entries.complete'),
       exportLogEntriesUrl: router.builder().params([params.id]).make('log_entries.export'),
+      exportParcellesUrl: router.builder().params([params.id]).make('parcelles.export'),
     })
   }
 
@@ -317,6 +321,27 @@ export default class ExploitationsController {
     createSuccessFlashMessage(session, `L'exploitation a été supprimée.`)
 
     return response.redirect().toRoute('exploitations.index')
+  }
+
+  async exportParcellesCsv({ bouncer, params, response }: HttpContext) {
+    const exploitationId = params.exploitationId
+    const exploitation = await Exploitation.findOrFail(exploitationId)
+
+    if (await bouncer.with(ExploitationPolicy).denies('write', exploitation)) {
+      return response.forbidden("Impossible d'exporter les données de l'exploitation")
+    }
+
+    const parcelles = await this.parcelleService.getAllParcellesForExploitation(exploitationId)
+    const csv = this.parcelleCsvService.generateCsv(parcelles)
+
+    const safeName = exploitation.name.replace(/[^a-zA-Z0-9]/g, '-').slice(0, 50)
+    const date = new Date().toISOString().slice(0, 10)
+    const filename = `parcelles-${safeName}-${date}.csv`
+
+    return response
+      .header('Content-Type', 'text/csv; charset=utf-8')
+      .header('Content-Disposition', `attachment; filename="${filename}"`)
+      .send(csv)
   }
 
   async detachParcelle({ request, response, auth, session }: HttpContext) {

--- a/app/models/parcelle.ts
+++ b/app/models/parcelle.ts
@@ -54,7 +54,7 @@ export default class Parcelle extends BaseModel {
   })
   declare centroid: { x: number; y: number } | null
 
-  @belongsTo(() => Culture, { localKey: 'cultureCode', foreignKey: 'code' })
+  @belongsTo(() => Culture, { localKey: 'code', foreignKey: 'cultureCode' })
   declare culture: BelongsTo<typeof Culture>
 
   @column.dateTime({ autoCreate: true })

--- a/app/models/parcelle.ts
+++ b/app/models/parcelle.ts
@@ -1,8 +1,8 @@
 import { DateTime } from 'luxon'
-import { BaseModel, beforeCreate, belongsTo, column, hasOne } from '@adonisjs/lucid/orm'
+import { BaseModel, beforeCreate, belongsTo, column } from '@adonisjs/lucid/orm'
 import { randomUUID } from 'node:crypto'
 import Exploitation from '#models/exploitation'
-import type { BelongsTo, HasOne } from '@adonisjs/lucid/types/relations'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import Culture from '#models/culture'
 
 export default class Parcelle extends BaseModel {
@@ -54,8 +54,8 @@ export default class Parcelle extends BaseModel {
   })
   declare centroid: { x: number; y: number } | null
 
-  @hasOne(() => Culture, { localKey: 'cultureCode', foreignKey: 'code' })
-  declare culture: HasOne<typeof Culture>
+  @belongsTo(() => Culture, { localKey: 'cultureCode', foreignKey: 'code' })
+  declare culture: BelongsTo<typeof Culture>
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime

--- a/app/models/parcelle.ts
+++ b/app/models/parcelle.ts
@@ -54,7 +54,7 @@ export default class Parcelle extends BaseModel {
   })
   declare centroid: { x: number; y: number } | null
 
-  @hasOne(() => Culture, { localKey: 'culture_code', foreignKey: 'code' })
+  @hasOne(() => Culture, { localKey: 'cultureCode', foreignKey: 'code' })
   declare culture: HasOne<typeof Culture>
 
   @column.dateTime({ autoCreate: true })

--- a/app/services/base_csv_service.ts
+++ b/app/services/base_csv_service.ts
@@ -1,0 +1,41 @@
+import { DateTime } from 'luxon'
+
+const SEPARATOR = ';'
+const LINE_END = '\r\n'
+const BOM = '\uFEFF'
+
+export abstract class BaseCsvService<T> {
+  protected abstract getHeaders(): string[]
+  protected abstract buildRow(item: T): string
+
+  generateCsv(items: T[]): string {
+    const rows = [
+      this.getHeaders()
+        .map((h) => this.escapeField(h))
+        .join(SEPARATOR),
+      ...items.map((item) => this.buildRow(item)),
+    ]
+
+    return BOM + rows.join(LINE_END)
+  }
+
+  protected buildRowFromFields(fields: (string | null | undefined)[]): string {
+    return fields.map((f) => this.escapeField(f)).join(SEPARATOR)
+  }
+
+  protected escapeField(value: string | null | undefined): string {
+    const str = value ?? ''
+    const safeStr = /^\s*[=+\-@]/.test(str) ? `'${str}` : str
+    return `"${safeStr.replace(/"/g, '""')}"`
+  }
+
+  protected formatDate(date: DateTime | null | undefined): string | null {
+    if (!date) return null
+    return date.toFormat('dd/MM/yyyy')
+  }
+
+  protected formatDateTime(date: DateTime | null | undefined): string | null {
+    if (!date) return null
+    return date.toFormat('dd/MM/yyyy HH:mm')
+  }
+}

--- a/app/services/log_entry_csv_service.ts
+++ b/app/services/log_entry_csv_service.ts
@@ -1,37 +1,13 @@
-import { DateTime } from 'luxon'
 import LogEntry from '#models/log_entry'
+import { BaseCsvService } from '#services/base_csv_service'
 
-const SEPARATOR = ';'
-const LINE_END = '\r\n'
-const BOM = '\uFEFF'
-
-const HEADERS = [
-  'Date',
-  'Titre',
-  'Notes',
-  'Auteur',
-  'Statut',
-  'Étiquettes',
-  'Créé le',
-  'Modifié le',
-]
-
-export class LogEntryCsvService {
-  /**
-   * Génère une chaîne CSV (avec BOM UTF-8) à partir d'une liste d'entrées de journal.
-   * Les relations author, tags et documents doivent être préchargées.
-   */
-  generateCsv(entries: LogEntry[]): string {
-    const rows = [
-      HEADERS.map((h) => this.escapeField(h)).join(SEPARATOR),
-      ...entries.map((entry) => this.buildRow(entry)),
-    ]
-
-    return BOM + rows.join(LINE_END)
+export class LogEntryCsvService extends BaseCsvService<LogEntry> {
+  protected getHeaders(): string[] {
+    return ['Date', 'Titre', 'Notes', 'Auteur', 'Statut', 'Étiquettes', 'Créé le', 'Modifié le']
   }
 
-  private buildRow(entry: LogEntry): string {
-    const fields = [
+  protected buildRow(entry: LogEntry): string {
+    return this.buildRowFromFields([
       this.formatDate(entry.date),
       entry.title,
       entry.notes,
@@ -40,27 +16,6 @@ export class LogEntryCsvService {
       entry.tags?.map((t) => t.name).join(' | ') ?? null,
       this.formatDateTime(entry.createdAt),
       this.formatDateTime(entry.updatedAt),
-    ]
-
-    return fields.map((f) => this.escapeField(f)).join(SEPARATOR)
-  }
-
-  private escapeField(value: string | null | undefined): string {
-    // Ensures the value is a string
-    const str = value ?? ''
-    // Protect against CSV injection by prefixing dangerous characters with a single quote
-    const safeStr = /^\s*[=+\-@]/.test(str) ? `'${str}` : str
-    // Wrap in double quotes and escape inner double quotes by doubling them
-    return `"${safeStr.replace(/"/g, '""')}"`
-  }
-
-  private formatDate(date: DateTime | null | undefined): string | null {
-    if (!date) return null
-    return date.toFormat('dd/MM/yyyy')
-  }
-
-  private formatDateTime(date: DateTime | null | undefined): string | null {
-    if (!date) return null
-    return date.toFormat('dd/MM/yyyy HH:mm')
+    ])
   }
 }

--- a/app/services/parcelle_csv_service.ts
+++ b/app/services/parcelle_csv_service.ts
@@ -1,0 +1,30 @@
+import Parcelle from '#models/parcelle'
+import { BaseCsvService } from '#services/base_csv_service'
+
+export class ParcelleCsvService extends BaseCsvService<Parcelle> {
+  protected getHeaders(): string[] {
+    return [
+      'Année',
+      'Identifiant RPG',
+      'Surface (ha)',
+      'Code culture',
+      'Culture',
+      'Commentaire',
+      'Créé le',
+      'Modifié le',
+    ]
+  }
+
+  protected buildRow(parcelle: Parcelle): string {
+    return this.buildRowFromFields([
+      parcelle.year?.toString() ?? null,
+      parcelle.rpgId,
+      parcelle.surface?.toString() ?? null,
+      parcelle.cultureCode,
+      parcelle.culture?.label ?? null,
+      parcelle.comment,
+      this.formatDateTime(parcelle.createdAt),
+      this.formatDateTime(parcelle.updatedAt),
+    ])
+  }
+}

--- a/app/services/parcelle_service.ts
+++ b/app/services/parcelle_service.ts
@@ -93,6 +93,14 @@ export class ParcelleService {
     return parcelles.map((parcelle) => parcelle.rpgId)
   }
 
+  async getAllParcellesForExploitation(exploitationId: string): Promise<Parcelle[]> {
+    return Parcelle.query()
+      .where('exploitationId', exploitationId)
+      .preload('culture')
+      .orderBy('year', 'desc')
+      .orderBy('rpgId', 'asc')
+  }
+
   async detachParcelleFromExploitation(exploitationId: string, rpgId: string, year: number) {
     const parcelle = await this.queryParcelleByRpgId(rpgId, year).first()
 

--- a/database/factories/parcelle_factory.ts
+++ b/database/factories/parcelle_factory.ts
@@ -1,0 +1,18 @@
+import factory from '@adonisjs/lucid/factories'
+import Parcelle from '#models/parcelle'
+import { ExploitationFactory } from '#database/factories/exploitation_factory'
+import { fakerFR as faker } from '@faker-js/faker'
+
+export const ParcelleFactory = factory
+  .define(Parcelle, async () => {
+    return {
+      year: faker.number.int({ min: 2020, max: 2026 }),
+      rpgId: faker.string.numeric(10),
+      surface: faker.number.float({ min: 0.1, max: 100, fractionDigits: 2 }),
+      cultureCode: null,
+      comment: null,
+      centroid: null,
+    }
+  })
+  .relation('exploitation', () => ExploitationFactory)
+  .build()

--- a/inertia/components/exploitation-id/ExploitationActionCard.tsx
+++ b/inertia/components/exploitation-id/ExploitationActionCard.tsx
@@ -15,10 +15,12 @@ const deleteExploitationModal = createModal({
 export function ExploitationActionCard({
   exploitation,
   exportLogEntriesUrl,
+  exportParcellesUrl,
   deleteExploitationUrl,
 }: {
   exploitation: ExploitationJson
   exportLogEntriesUrl: string
+  exportParcellesUrl: string
   deleteExploitationUrl: string
 }) {
   const [isDeleteButtonDisabled, setIsDeleteButtonDisabled] = useState(true)
@@ -30,6 +32,12 @@ export function ExploitationActionCard({
         href={exportLogEntriesUrl}
       >
         Exporter le journal de bord
+      </a>
+      <a
+        className="fr-btn fr-btn--secondary fr-icon-download-line fr-btn--icon-left fr-mb-2w"
+        href={exportParcellesUrl}
+      >
+        Exporter les parcelles de l'exploitation
       </a>
       <DeleteAlert
         title="Supprimer l'exploitation"

--- a/inertia/pages/exploitations/id.tsx
+++ b/inertia/pages/exploitations/id.tsx
@@ -18,6 +18,7 @@ export default function SingleExploitation({
   deleteExploitationUrl,
   editExploitationUrl,
   exportLogEntriesUrl,
+  exportParcellesUrl,
 }: InferPageProps<ExploitationsController, 'get'>) {
   return (
     <Layout>
@@ -73,6 +74,7 @@ export default function SingleExploitation({
             <ExploitationActionCard
               exploitation={exploitation}
               exportLogEntriesUrl={exportLogEntriesUrl}
+              exportParcellesUrl={exportParcellesUrl}
               deleteExploitationUrl={deleteExploitationUrl}
             />
           </aside>

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -79,6 +79,13 @@ router
           .as('parcelles.note.update')
 
         router
+          .get('exploitations/:exploitationId/parcelles/export', [
+            ExploitationsController,
+            'exportParcellesCsv',
+          ])
+          .as('parcelles.export')
+
+        router
           .get('exploitations/:exploitationId/journal', [LogEntriesController, 'index'])
           .as('log_entries.index')
 

--- a/tests/unit/parcelle/parcelle_csv_service.spec.ts
+++ b/tests/unit/parcelle/parcelle_csv_service.spec.ts
@@ -1,0 +1,106 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { ParcelleCsvService } from '#services/parcelle_csv_service'
+import { ParcelleFactory } from '#database/factories/parcelle_factory'
+
+const BOM = '\uFEFF'
+
+function parseRows(csv: string): string[] {
+  return csv.replace(BOM, '').split('\r\n')
+}
+
+function parseFields(row: string): string[] {
+  return row.split(';')
+}
+
+test.group('ParcelleCsvService', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('generates only the header row for an empty list', ({ assert }) => {
+    const csv = new ParcelleCsvService().generateCsv([])
+    const rows = parseRows(csv)
+
+    assert.lengthOf(rows, 1)
+    assert.include(rows[0], '"Identifiant RPG"')
+    assert.include(rows[0], '"Surface (ha)"')
+  })
+
+  test('output starts with UTF-8 BOM', async ({ assert }) => {
+    const parcelle = await ParcelleFactory.with('exploitation').create()
+    const csv = new ParcelleCsvService().generateCsv([parcelle])
+    assert.isTrue(csv.startsWith(BOM))
+  })
+
+  test('generates one data row per parcelle', async ({ assert }) => {
+    const parcelles = await ParcelleFactory.with('exploitation').createMany(3)
+    const csv = new ParcelleCsvService().generateCsv(parcelles)
+    assert.lengthOf(parseRows(csv), 4) // 1 header + 3 data rows
+  })
+
+  test('includes year, rpgId and surface in the row', async ({ assert }) => {
+    const parcelle = await ParcelleFactory.merge({
+      year: 2025,
+      rpgId: '1234567890',
+      surface: 12.5,
+    })
+      .with('exploitation')
+      .create()
+
+    const csv = new ParcelleCsvService().generateCsv([parcelle])
+    const fields = parseFields(parseRows(csv)[1])
+
+    assert.equal(fields[0], '"2025"')
+    assert.equal(fields[1], '"1234567890"')
+    assert.equal(fields[2], '"12.5"')
+  })
+
+  test('outputs empty field when surface is null', async ({ assert }) => {
+    const parcelle = await ParcelleFactory.merge({ surface: null }).with('exploitation').create()
+    const csv = new ParcelleCsvService().generateCsv([parcelle])
+    const fields = parseFields(parseRows(csv)[1])
+    assert.equal(fields[2], '""')
+  })
+
+  test('outputs empty field when comment is null', async ({ assert }) => {
+    const parcelle = await ParcelleFactory.merge({ comment: null }).with('exploitation').create()
+    const csv = new ParcelleCsvService().generateCsv([parcelle])
+    const fields = parseFields(parseRows(csv)[1])
+    // Commentaire is at index 5
+    assert.equal(fields[5], '""')
+  })
+
+  test('includes comment when present', async ({ assert }) => {
+    const parcelle = await ParcelleFactory.merge({ comment: 'Terrain argileux' })
+      .with('exploitation')
+      .create()
+    const csv = new ParcelleCsvService().generateCsv([parcelle])
+    assert.include(csv, '"Terrain argileux"')
+  })
+
+  test('prefixes CSV injection characters with a single quote', async ({ assert }) => {
+    const parcelle = await ParcelleFactory.merge({ comment: '=SUM(A1:B2)' })
+      .with('exploitation')
+      .create()
+    const csv = new ParcelleCsvService().generateCsv([parcelle])
+    assert.include(csv, '"\'=SUM(A1:B2)"')
+  })
+
+  test('escapes double quotes by doubling them', async ({ assert }) => {
+    const parcelle = await ParcelleFactory.merge({ comment: 'dit "attention"' })
+      .with('exploitation')
+      .create()
+    const csv = new ParcelleCsvService().generateCsv([parcelle])
+    assert.include(csv, '"dit ""attention"""')
+  })
+
+  test('outputs empty culture fields when cultureCode is null', async ({ assert }) => {
+    const parcelle = await ParcelleFactory.merge({ cultureCode: null })
+      .with('exploitation')
+      .create()
+    const csv = new ParcelleCsvService().generateCsv([parcelle])
+    const fields = parseFields(parseRows(csv)[1])
+    // Code culture (index 3) and Culture label (index 4)
+    assert.equal(fields[3], '""')
+    assert.equal(fields[4], '""')
+  })
+})


### PR DESCRIPTION
Dépend de #371 

Cette PR ajoute la possibilité d'exporter les parcelles associées à une exploitation en CSV. 

Dans un premier temps, aucun filtrage sur l'année n'est fait afin de simplifier le développement. On pourra affiner le comportement des exports de données liées au millésime l'année prochaine.

L'interface d'export est également temporaire, un sélecteur plus élégant sera implémenté lors d'une prochaine PR.

<img width="1234" height="1004" alt="image" src="https://github.com/user-attachments/assets/4136a8cf-4746-46ff-b8e5-bd32db9a8a5e" />
