### PR TITLE
Corrige la transparence des résultats sur le composant autocomplete

### DIFF
--- a/inertia/components/search-autocomplete.tsx
+++ b/inertia/components/search-autocomplete.tsx
@@ -112,6 +112,7 @@ export default function SearchAutocomplete<T>({
             left: 0,
             border: '1px solid var(--border-default-grey)',
             pointerEvents: 'auto',
+            zIndex: 1,
           }}
           role="listbox"
         >


### PR DESCRIPTION
# Avant : 

<img width="856" height="980" alt="image" src="https://github.com/user-attachments/assets/685b5ccf-b8f2-4842-b7a5-37a333aa9b32" />

# Après : 

<img width="869" height="980" alt="image" src="https://github.com/user-attachments/assets/ee59372b-edc0-4ef8-b1ea-27ac809d8df4" />

Fix #349 