### PR TITLE
Export des données AAC

### DIFF
--- a/app/controllers/aac_controller.ts
+++ b/app/controllers/aac_controller.ts
@@ -57,10 +57,7 @@ export default class AacController {
           .builder()
           .params([params.code])
           .make('aac.export.cultureEvolution'),
-        qualiteEau: router
-          .builder()
-          .params([params.code, new Date().getUTCFullYear()])
-          .make('aac.export.qualite'),
+        qualiteEau: router.builder().params([params.code]).make('aac.export.qualite'),
       },
     })
   }

--- a/app/controllers/aac_controller.ts
+++ b/app/controllers/aac_controller.ts
@@ -4,12 +4,17 @@ import { AacService } from '#services/aac_service'
 import { AacDto } from '../dto/aac_dto.js'
 import { analysesSummaryValidator, analysesValidator, yearRangeValidator } from '#validators/aac'
 import type { AacAnalysesSummaryJson } from '../../types/aac.js'
+import { AacCsvService } from '#services/aac_csv_service'
+import router from '@adonisjs/core/services/router'
 
 const PER_PAGE = 20
 
 @inject()
 export default class AacController {
-  constructor(public aacService: AacService) {}
+  constructor(
+    public aacService: AacService,
+    public aacCsvService: AacCsvService
+  ) {}
 
   async index({ request, inertia }: HttpContext) {
     // Backward compatibility for legacy bookmarks/links using page/recherche/commune.
@@ -42,7 +47,22 @@ export default class AacController {
       return response.abort(`AAC avec le code "${params.code}" introuvable`, 404)
     }
 
-    return inertia.render('aac/id', { aac: AacDto.fromRaw(raw) })
+    return inertia.render('aac/id', {
+      aac: AacDto.fromRaw(raw),
+      exportUrls: {
+        infoGenerale: router.builder().params([params.code]).make('aac.export.infoGenerale'),
+        captages: router.builder().params([params.code]).make('aac.export.captages'),
+        assolement: router.builder().params([params.code]).make('aac.export.assolement'),
+        cultureEvolution: router
+          .builder()
+          .params([params.code])
+          .make('aac.export.cultureEvolution'),
+        qualiteEau: router
+          .builder()
+          .params([params.code, new Date().getUTCFullYear()])
+          .make('aac.export.qualite'),
+      },
+    })
   }
 
   async showInstallation({ params, inertia, response }: HttpContext) {
@@ -150,6 +170,56 @@ export default class AacController {
 
     const data = await this.aacService.getAnalysesRobinet(params.installationCode, year)
     return response.json(data)
+  }
+
+  async exportInfoGenerale({ params, response }: HttpContext) {
+    return this.sendCsvExport(response, params.code, 'info-generale', () =>
+      this.aacCsvService.exportInfoGenerale(params.code)
+    )
+  }
+
+  async exportCaptages({ params, response }: HttpContext) {
+    return this.sendCsvExport(response, params.code, 'captages', () =>
+      this.aacCsvService.exportCaptages(params.code)
+    )
+  }
+
+  async exportAssolement({ params, response }: HttpContext) {
+    return this.sendCsvExport(response, params.code, 'assolement', () =>
+      this.aacCsvService.exportAssolement(params.code)
+    )
+  }
+
+  async exportCultureEvolution({ params, response }: HttpContext) {
+    return this.sendCsvExport(response, params.code, 'culture-evolution', () =>
+      this.aacCsvService.exportCultureEvolution(params.code)
+    )
+  }
+
+  async exportQualiteEau({ params, response }: HttpContext) {
+    return this.sendCsvExport(response, params.code, 'qualite-eau', () =>
+      this.aacCsvService.exportQualiteEau(params.code)
+    )
+  }
+
+  private async sendCsvExport(
+    response: HttpContext['response'],
+    code: string,
+    suffix: string,
+    generate: () => Promise<string | null>
+  ) {
+    const csv = await generate()
+    if (!csv) {
+      return response.abort(`AAC avec le code "${code}" introuvable`, 404)
+    }
+
+    const date = new Date().toISOString().slice(0, 10)
+    const filename = `aac-${code}-${suffix}-${date}.csv`
+
+    return response
+      .header('Content-Type', 'text/csv; charset=utf-8')
+      .header('Content-Disposition', `attachment; filename="${filename}"`)
+      .send(csv)
   }
 
   async analysesYears({ params, response }: HttpContext) {

--- a/app/services/aac_csv_service.ts
+++ b/app/services/aac_csv_service.ts
@@ -1,0 +1,287 @@
+import { AacService } from '#services/aac_service'
+import { AacDto } from '../dto/aac_dto.js'
+import { inject } from '@adonisjs/core'
+import { InstallationInfo, CultureInfo, AacJson } from '../../types/aac.js'
+
+const SEPARATOR = ';'
+const LINE_END = '\r\n'
+const BOM = '\uFEFF'
+
+function escapeField(value: string | null | undefined): string {
+  const str = value ?? ''
+  const safeStr = /^\s*[=+\-@]/.test(str) ? `'${str}` : str
+  return `"${safeStr.replace(/"/g, '""')}"`
+}
+
+function buildRow(fields: (string | null | undefined)[]): string {
+  return fields.map((f) => escapeField(f)).join(SEPARATOR)
+}
+
+function buildSection(headers: string[], rows: string[]): string {
+  const lines = [buildRow(headers), ...rows, '']
+  return lines.join(LINE_END)
+}
+
+function wrapCsv(sections: string[]): string {
+  return BOM + sections.join(LINE_END)
+}
+
+@inject()
+export class AacCsvService {
+  constructor(private aacService: AacService) {}
+
+  private async getAacDto(aacCode: string): Promise<AacJson | null> {
+    const raw = await this.aacService.getByCode(aacCode)
+    if (!raw) return null
+    return AacDto.fromRaw(raw)
+  }
+
+  private buildInfoGeneraleSection(aac: AacJson): string {
+    return buildSection(
+      [
+        'Code',
+        'Nom',
+        'Prioritaire',
+        'Surface (ha)',
+        'Captages actifs',
+        'Installations',
+        'Surface agricole (ha)',
+        'Parcelles',
+        'Date création',
+        'Date MAJ',
+      ],
+      [
+        buildRow([
+          aac.code,
+          aac.nom,
+          aac.prioritaire ? 'Oui' : 'Non',
+          String(aac.surface ?? ''),
+          String(aac.nb_captages_actifs ?? ''),
+          String(aac.nb_installations ?? ''),
+          String(aac.surface_agricole ?? ''),
+          String(aac.nb_parcelles ?? ''),
+          aac.date_creation,
+          aac.date_maj,
+        ]),
+      ]
+    )
+  }
+
+  private buildCaptagesSection(installations: InstallationInfo[]): string {
+    const headers = [
+      'Code',
+      'Nom',
+      'Code BSS',
+      'Commune',
+      'Département',
+      'Type',
+      'Nature',
+      'Usage',
+      'État',
+      'Code PPE',
+      'Prioritaire',
+      'Captage rattaché - Code',
+      'Captage rattaché - Nom',
+      'Captage rattaché - Code BSS',
+      'Captage rattaché - État',
+    ]
+    const rows: string[] = []
+    for (const inst of installations) {
+      const captages = inst.captages_rattaches ?? []
+      if (captages.length === 0) {
+        rows.push(
+          buildRow([
+            inst.code,
+            inst.nom,
+            inst.code_bss,
+            inst.commune,
+            inst.departement,
+            inst.type,
+            inst.nature,
+            inst.usage,
+            inst.etat,
+            inst.code_ppe,
+            inst.prioritaire ? 'Oui' : 'Non',
+            null,
+            null,
+            null,
+            null,
+          ])
+        )
+      } else {
+        for (const cap of captages) {
+          rows.push(
+            buildRow([
+              inst.code,
+              inst.nom,
+              inst.code_bss,
+              inst.commune,
+              inst.departement,
+              inst.type,
+              inst.nature,
+              inst.usage,
+              inst.etat,
+              inst.code_ppe,
+              inst.prioritaire ? 'Oui' : 'Non',
+              cap.code,
+              cap.nom,
+              cap.code_bss,
+              cap.etat,
+            ])
+          )
+        }
+      }
+    }
+    return buildSection(headers, rows)
+  }
+
+  private buildAssolementSection(aac: AacJson): string {
+    const assolementHeaders = ['Zone', 'Culture', 'Nb parcelles', 'Surface (ha)', 'SAU (%)']
+    const assolementRows: string[] = []
+
+    const zones: { label: string; data: Record<string, CultureInfo> | null }[] = [
+      { label: 'SAU (Surface Agricole Utile)', data: aac.surface_agricole_utile },
+      { label: 'PPE (Périmètre de Protection Éloigné)', data: aac.surface_agricole_ppe },
+      { label: 'PPR (Périmètre de Protection Rapproché)', data: aac.surface_agricole_ppr },
+    ]
+
+    for (const zone of zones) {
+      if (!zone.data) continue
+      for (const [culture, info] of Object.entries(zone.data)) {
+        if (!info) continue
+        assolementRows.push(
+          buildRow([
+            zone.label,
+            culture,
+            info.nb_parcelles !== null ? String(info.nb_parcelles) : '',
+            info.surface !== null ? String(info.surface) : '',
+            info.SAU !== null ? String(info.SAU) : '',
+          ])
+        )
+      }
+    }
+
+    if (aac.surface_agricole_bio) {
+      const bio = aac.surface_agricole_bio
+      assolementRows.push(
+        buildRow([
+          'Bio (global)',
+          'Total',
+          String(bio.nb_parcelles ?? ''),
+          String(bio.surface ?? ''),
+          String(bio.part_bio ?? ''),
+        ])
+      )
+      for (const ev of bio.evolution ?? []) {
+        assolementRows.push(
+          buildRow([
+            'Bio (évolution)',
+            String(ev.annee),
+            String(ev.nb_parcelles ?? ''),
+            String(ev.surface ?? ''),
+            '',
+          ])
+        )
+      }
+    }
+
+    return buildSection(assolementHeaders, assolementRows)
+  }
+
+  private buildCultureEvolutionSection(aac: AacJson): string | null {
+    if (!aac.culture_evolution?.repartition) return null
+    const evoHeaders = ['Année', 'Culture', 'Surface (ha)', 'Nb parcelles']
+    const evoRows: string[] = []
+    for (const [culture, years] of Object.entries(aac.culture_evolution.repartition)) {
+      for (const [year, detail] of Object.entries(years)) {
+        if (!detail) continue
+        evoRows.push(
+          buildRow([
+            culture,
+            year,
+            String(detail.surface_ha ?? ''),
+            String(detail.nb_parcelles ?? ''),
+          ])
+        )
+      }
+    }
+    return buildSection(evoHeaders, evoRows)
+  }
+
+  private async buildQualiteEauSection(installations: InstallationInfo[]): Promise<string | null> {
+    const headers: string[] = []
+    const rows: string[] = []
+    let headersSet = false
+
+    for (const inst of installations) {
+      let years: string[]
+      try {
+        years = await this.aacService.getAnalysesRobinetYears(inst.code)
+      } catch {
+        continue
+      }
+
+      for (const yearStr of years) {
+        const y = Number.parseInt(yearStr, 10)
+        if (Number.isNaN(y)) continue
+
+        let analyses: Record<string, unknown>[]
+        try {
+          analyses = await this.aacService.getAnalysesRobinet(inst.code, y)
+        } catch {
+          continue
+        }
+
+        for (const analyse of analyses) {
+          if (!headersSet && Object.keys(analyse).length > 0) {
+            headers.push('Installation', ...Object.keys(analyse))
+            headersSet = true
+          }
+          rows.push(
+            buildRow([
+              inst.code,
+              ...Object.values(analyse).map((v) => (v !== null ? String(v) : '')),
+            ])
+          )
+        }
+      }
+    }
+
+    if (rows.length === 0) return null
+    return buildSection(headers, rows)
+  }
+
+  async exportInfoGenerale(aacCode: string): Promise<string | null> {
+    const aac = await this.getAacDto(aacCode)
+    if (!aac) return null
+    return wrapCsv([this.buildInfoGeneraleSection(aac)])
+  }
+
+  async exportCaptages(aacCode: string): Promise<string | null> {
+    const aac = await this.getAacDto(aacCode)
+    if (!aac) return null
+    return wrapCsv([this.buildCaptagesSection(aac.installations ?? [])])
+  }
+
+  async exportAssolement(aacCode: string): Promise<string | null> {
+    const aac = await this.getAacDto(aacCode)
+    if (!aac) return null
+    return wrapCsv([this.buildAssolementSection(aac)])
+  }
+
+  async exportCultureEvolution(aacCode: string): Promise<string | null> {
+    const aac = await this.getAacDto(aacCode)
+    if (!aac) return null
+    const section = this.buildCultureEvolutionSection(aac)
+    if (!section) return null
+    return wrapCsv([section])
+  }
+
+  async exportQualiteEau(aacCode: string): Promise<string | null> {
+    const aac = await this.getAacDto(aacCode)
+    if (!aac) return null
+    const section = await this.buildQualiteEauSection(aac.installations ?? [])
+    if (!section) return null
+    return wrapCsv([section])
+  }
+}

--- a/app/services/aac_csv_service.ts
+++ b/app/services/aac_csv_service.ts
@@ -211,40 +211,16 @@ export class AacCsvService {
   private async buildQualiteEauSection(installations: InstallationInfo[]): Promise<string | null> {
     const headers: string[] = []
     const rows: string[] = []
-    let headersSet = false
 
-    for (const inst of installations) {
-      let years: string[]
-      try {
-        years = await this.aacService.getAnalysesRobinetYears(inst.code)
-      } catch {
-        continue
-      }
+    const codes = installations.map((inst) => inst.code)
+    const analyses = await this.aacService.getAnalysesRobinetForExport(codes)
 
-      for (const yearStr of years) {
-        const y = Number.parseInt(yearStr, 10)
-        if (Number.isNaN(y)) continue
+    if (analyses.length > 0 && Object.keys(analyses[0]).length > 0) {
+      headers.push(...Object.keys(analyses[0]))
+    }
 
-        let analyses: Record<string, unknown>[]
-        try {
-          analyses = await this.aacService.getAnalysesRobinet(inst.code, y)
-        } catch {
-          continue
-        }
-
-        for (const analyse of analyses) {
-          if (!headersSet && Object.keys(analyse).length > 0) {
-            headers.push('Installation', ...Object.keys(analyse))
-            headersSet = true
-          }
-          rows.push(
-            buildRow([
-              inst.code,
-              ...Object.values(analyse).map((v) => (v !== null ? String(v) : '')),
-            ])
-          )
-        }
-      }
+    for (const analyse of analyses) {
+      rows.push(buildRow(Object.values(analyse).map((v) => (v !== null ? String(v) : ''))))
     }
 
     if (rows.length === 0) return null

--- a/app/services/aac_csv_service.ts
+++ b/app/services/aac_csv_service.ts
@@ -189,23 +189,48 @@ export class AacCsvService {
   }
 
   private buildCultureEvolutionSection(aac: AacJson): string | null {
-    if (!aac.culture_evolution?.repartition) return null
-    const evoHeaders = ['Année', 'Culture', 'Surface (ha)', 'Nb parcelles']
-    const evoRows: string[] = []
-    for (const [year, culture] of Object.entries(aac.culture_evolution.repartition)) {
-      for (const [cultureName, detail] of Object.entries(culture)) {
-        if (!detail) continue
-        evoRows.push(
-          buildRow([
-            year,
-            cultureName,
-            String(detail.surface_ha ?? ''),
-            String(detail.nb_parcelles ?? ''),
-          ])
-        )
-      }
+    const repartition = aac.culture_evolution?.repartition
+    if (!repartition) return null
+
+    const years = Object.keys(repartition).sort((a, b) => Number(a) - Number(b))
+    if (years.length === 0) return null
+
+    const cultureNames = Array.from(
+      new Set(years.flatMap((year) => Object.keys(repartition[year] ?? {})))
+    ).sort((a, b) => a.localeCompare(b))
+
+    if (cultureNames.length === 0) return null
+
+    const headers = ['Culture', 'Indicateur', ...years]
+    const rows: string[] = []
+
+    for (const cultureName of cultureNames) {
+      const surfaceRow = buildRow([
+        cultureName,
+        'Surface (ha)',
+        ...years.map((year) => {
+          const detail = repartition[year]?.[cultureName]
+          return detail?.surface_ha !== null && detail?.surface_ha !== undefined
+            ? String(detail.surface_ha)
+            : ''
+        }),
+      ])
+
+      const parcellesRow = buildRow([
+        cultureName,
+        'Nb parcelles',
+        ...years.map((year) => {
+          const detail = repartition[year]?.[cultureName]
+          return detail?.nb_parcelles !== null && detail?.nb_parcelles !== undefined
+            ? String(detail.nb_parcelles)
+            : ''
+        }),
+      ])
+
+      rows.push(surfaceRow, parcellesRow)
     }
-    return buildSection(evoHeaders, evoRows)
+
+    return buildSection(headers, rows)
   }
 
   private async buildQualiteEauSection(installations: InstallationInfo[]): Promise<string | null> {

--- a/app/services/aac_csv_service.ts
+++ b/app/services/aac_csv_service.ts
@@ -192,13 +192,13 @@ export class AacCsvService {
     if (!aac.culture_evolution?.repartition) return null
     const evoHeaders = ['Année', 'Culture', 'Surface (ha)', 'Nb parcelles']
     const evoRows: string[] = []
-    for (const [culture, years] of Object.entries(aac.culture_evolution.repartition)) {
-      for (const [year, detail] of Object.entries(years)) {
+    for (const [year, culture] of Object.entries(aac.culture_evolution.repartition)) {
+      for (const [cultureName, detail] of Object.entries(culture)) {
         if (!detail) continue
         evoRows.push(
           buildRow([
-            culture,
             year,
+            cultureName,
             String(detail.surface_ha ?? ''),
             String(detail.nb_parcelles ?? ''),
           ])

--- a/app/services/aac_service.ts
+++ b/app/services/aac_service.ts
@@ -631,6 +631,35 @@ export class AacService {
     }
   }
 
+
+  async getAnalysesRobinetForExport(
+    installationCodes: string[]
+  ): Promise<Record<string, unknown>[]> {
+    if (installationCodes.length === 0) {
+      return []
+    }
+
+    const conn = await getConnection()
+    const placeholders = installationCodes.map((_, index) => `$${index + 2}`).join(', ')
+
+    const stmt = await conn.prepare(
+      'SELECT "code_insee", "nom_commune", "code_installation", "nom_installation", "date_prelevement", "heure_prelevement", "code_brgm", "resultat", "code_unite", "libelle_parametre", "limite_qualite", "reference_qualite", "captage_prioritaire" ' +
+      'FROM read_parquet($1) ' +
+      `WHERE "code_installation" IN (${placeholders}) ` +
+      'ORDER BY "date_prelevement" DESC NULLS LAST'
+    )
+
+    stmt.bindVarchar(1, getAnalysesRobinetPath())
+
+    installationCodes.forEach((code, index) => {
+      stmt.bindVarchar(index + 2, code)
+    })
+
+    const result = await stmt.run()
+    const rows = (await result.getRowObjects()) as Array<Record<string, unknown>>
+    return rows.map((r) => normalizeValue(r) as Record<string, unknown>)
+  }
+
   /**
    * Returns all AAC names ordered alphabetically.
    */

--- a/inertia/components/aac-id/AacActionCard.tsx
+++ b/inertia/components/aac-id/AacActionCard.tsx
@@ -12,6 +12,44 @@ type ExportUrls = {
   qualiteEau: string
 }
 
+function getFilenameFromDisposition(disposition: string | null) {
+  if (!disposition) return 'export.csv'
+
+  const utf8Filename = disposition.match(/filename\*=UTF-8''([^;]+)/i)?.[1]
+  if (utf8Filename) {
+    return decodeURIComponent(utf8Filename)
+  }
+
+  return disposition.match(/filename="?([^";]+)"?/i)?.[1] ?? 'export.csv'
+}
+
+async function downloadCsv(url: string) {
+  const response = await fetch(url, {
+    credentials: 'same-origin',
+  })
+
+  if (!response.ok) {
+    throw new Error(`Erreur lors de l'export : ${response.status} ${response.statusText}`)
+  }
+
+  const blob = await response.blob()
+  const filename = getFilenameFromDisposition(response.headers.get('Content-Disposition'))
+  const objectUrl = window.URL.createObjectURL(blob)
+  const link = document.createElement('a')
+
+  link.href = objectUrl
+  link.download = filename
+  link.style.display = 'none'
+
+  document.body.append(link)
+  link.click()
+  link.remove()
+
+  window.setTimeout(() => {
+    window.URL.revokeObjectURL(objectUrl)
+  }, 1000)
+}
+
 export function AacActionCard({ exportUrls }: { exportUrls: ExportUrls }) {
   const [exportUrl, setExportUrl] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -21,6 +59,7 @@ export function AacActionCard({ exportUrls }: { exportUrls: ExportUrls }) {
       <div className="flex items-end gap-2 fr-mb-3w">
         <Select
           className="flex-1 fr-mb-0"
+          disabled={isLoading}
           options={[
             { value: 'infoGenerale', label: 'Informations générales' },
             { value: 'captages', label: 'Captages' },
@@ -39,30 +78,20 @@ export function AacActionCard({ exportUrls }: { exportUrls: ExportUrls }) {
         <Button
           priority={'secondary'}
           title={'Export des données'}
+          aria-busy={isLoading}
           disabled={exportUrl === null || isLoading}
           onClick={() => {
             if (!exportUrl) return
 
             setIsLoading(true)
-            fetch(exportUrl)
-              .then(async (res) => {
-                if (!res.ok) {
-                  throw new Error(`Erreur lors de l'export : ${res.statusText}`)
-                }
-                const disposition = res.headers.get('Content-Disposition')
-                const filename = disposition?.match(/filename="?([^"]+)"?/)?.[1] ?? 'export'
-                const blob = await res.blob()
-                return { blob, filename }
+
+            downloadCsv(exportUrl)
+              .catch((error) => {
+                console.error(error)
               })
-              .then(({ blob, filename }) => {
-                const url = URL.createObjectURL(blob)
-                const a = document.createElement('a')
-                a.href = url
-                a.download = filename
-                a.click()
-                URL.revokeObjectURL(url)
+              .finally(() => {
+                setIsLoading(false)
               })
-              .finally(() => setIsLoading(false))
           }}
         >
           {isLoading ? (

--- a/inertia/components/aac-id/AacActionCard.tsx
+++ b/inertia/components/aac-id/AacActionCard.tsx
@@ -1,0 +1,74 @@
+import SmallSection from '~/ui/SmallSection'
+import { useState } from 'react'
+import Select from '@codegouvfr/react-dsfr/SelectNext'
+import Button from '@codegouvfr/react-dsfr/Button'
+import Loader from '~/ui/Loader'
+
+type ExportUrls = {
+  infoGenerale: string
+  captages: string
+  assolement: string
+  cultureEvolution: string
+  qualiteEau: string
+}
+
+export function AacActionCard({ exportUrls }: { exportUrls: ExportUrls }) {
+  const [exportUrl, setExportUrl] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  return (
+    <SmallSection title="Actions" priority="secondary" hasBorder>
+      <div className="flex items-end gap-2 fr-mb-3w">
+        <Select
+          className="flex-1 fr-mb-0"
+          options={[
+            { value: 'infoGenerale', label: 'Informations générales' },
+            { value: 'captages', label: 'Captages' },
+            { value: 'assolement', label: 'Assolement' },
+            { value: 'cultureEvolution', label: 'Évolution des cultures' },
+            { value: 'qualiteEau', label: "Qualité de l'eau" },
+          ]}
+          label={'Export des données'}
+          nativeSelectProps={{
+            onChange: (e) => {
+              const key = e.target.value as keyof ExportUrls
+              setExportUrl(exportUrls[key] ?? null)
+            },
+          }}
+        />
+        <Button
+          priority={'secondary'}
+          title={'Export des données'}
+          disabled={exportUrl === null || isLoading}
+          onClick={() => {
+            if (!exportUrl) return
+
+            setIsLoading(true)
+            fetch(exportUrl)
+              .then(async (res) => {
+                const disposition = res.headers.get('Content-Disposition')
+                const filename = disposition?.match(/filename="?([^"]+)"?/)?.[1] ?? 'export'
+                const blob = await res.blob()
+                return { blob, filename }
+              })
+              .then(({ blob, filename }) => {
+                const url = URL.createObjectURL(blob)
+                const a = document.createElement('a')
+                a.href = url
+                a.download = filename
+                a.click()
+                URL.revokeObjectURL(url)
+              })
+              .finally(() => setIsLoading(false))
+          }}
+        >
+          {isLoading ? (
+            <Loader size={'sm'} type={'dots'} />
+          ) : (
+            <div className="fr-icon-download-line" />
+          )}
+        </Button>
+      </div>
+    </SmallSection>
+  )
+}

--- a/inertia/components/aac-id/AacActionCard.tsx
+++ b/inertia/components/aac-id/AacActionCard.tsx
@@ -46,6 +46,9 @@ export function AacActionCard({ exportUrls }: { exportUrls: ExportUrls }) {
             setIsLoading(true)
             fetch(exportUrl)
               .then(async (res) => {
+                if (!res.ok) {
+                  throw new Error(`Erreur lors de l'export : ${res.statusText}`)
+                }
                 const disposition = res.headers.get('Content-Disposition')
                 const filename = disposition?.match(/filename="?([^"]+)"?/)?.[1] ?? 'export'
                 const blob = await res.blob()
@@ -65,7 +68,7 @@ export function AacActionCard({ exportUrls }: { exportUrls: ExportUrls }) {
           {isLoading ? (
             <Loader size={'sm'} type={'dots'} />
           ) : (
-            <div className="fr-icon-download-line" />
+            <div className="fr-icon-download-line" aria-label={'Export des données'} />
           )}
         </Button>
       </div>

--- a/inertia/pages/aac/id.tsx
+++ b/inertia/pages/aac/id.tsx
@@ -13,8 +13,9 @@ import { useEffect, useState } from 'react'
 import AacTerritoireSection from '~/components/aac-id/aac-territoire-section'
 import AacAgricultureSection from '~/components/aac-id/aac-agriculture-section'
 import AacCaptages from '~/components/aac-id/aac-captages'
+import { AacActionCard } from '~/components/aac-id/AacActionCard'
 
-export default function AacShow({ aac }: InferPageProps<AacController, 'show'>) {
+export default function AacShow({ aac, exportUrls }: InferPageProps<AacController, 'show'>) {
   const communeArray = map(aac.communes?.communes ?? {}, (info, nom) => ({ nom, ...info }))
 
   const { url } = usePage()
@@ -70,6 +71,7 @@ export default function AacShow({ aac }: InferPageProps<AacController, 'show'>) 
           <aside className="flex flex-col gap-4">
             <AacInformationsCard {...aac} />
             <AacCommunesCard communes={communeArray} />
+            <AacActionCard exportUrls={exportUrls} />
           </aside>
 
           <Tabs

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -170,7 +170,7 @@ router
           .where('code', /^\d+$/)
           .as('aac.export.cultureEvolution')
         router
-          .get('aac/:code/export/qualite/', [AacController, 'exportQualiteEau'])
+          .get('aac/:code/export/qualite', [AacController, 'exportQualiteEau'])
           .where('code', /^\d+$/)
           .as('aac.export.qualite')
         router

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -154,6 +154,26 @@ router
           .where('code', /^\d+$/)
           .as('aac.analysesSummary')
         router
+          .get('aac/:code/export/general', [AacController, 'exportInfoGenerale'])
+          .where('code', /^\d+$/)
+          .as('aac.export.infoGenerale')
+        router
+          .get('aac/:code/export/captages', [AacController, 'exportCaptages'])
+          .where('code', /^\d+$/)
+          .as('aac.export.captages')
+        router
+          .get('aac/:code/export/assolement', [AacController, 'exportAssolement'])
+          .where('code', /^\d+$/)
+          .as('aac.export.assolement')
+        router
+          .get('aac/:code/export/culture-evolution', [AacController, 'exportCultureEvolution'])
+          .where('code', /^\d+$/)
+          .as('aac.export.cultureEvolution')
+        router
+          .get('aac/:code/export/qualite/', [AacController, 'exportQualiteEau'])
+          .where('code', /^\d+$/)
+          .as('aac.export.qualite')
+        router
           .get('aac/:code/installations/:installationCode', [AacController, 'showInstallation'])
           .where('code', /^\d+$/)
           .as('aac.showInstallation')

--- a/tests/unit/aac/aac_csv_service.spec.ts
+++ b/tests/unit/aac/aac_csv_service.spec.ts
@@ -1,0 +1,259 @@
+import { test } from '@japa/runner'
+import { AacCsvService } from '#services/aac_csv_service'
+import { AacService } from '#services/aac_service'
+import { AacJson } from '../../../types/aac.js'
+
+const BOM = '\uFEFF'
+
+function parseRows(csv: string): string[] {
+  return csv.replace(BOM, '').split('\r\n')
+}
+
+function parseFields(row: string): string[] {
+  return row.split(';')
+}
+
+function buildAacFixture(overrides: Partial<AacJson> = {}): AacJson {
+  return {
+    code: '12345',
+    nom: 'AAC Test',
+    prioritaire: true,
+    date_creation: '2020-01-01',
+    date_maj: '2024-06-15',
+    bbox: null,
+    surface: 150.5,
+    nb_captages_actifs: 3,
+    nb_installations: 2,
+    surface_agricole: 120,
+    nb_parcelles: 45,
+    communes: { nb_communes: 2, communes: {} },
+    surface_agricole_utile: {
+      Blé: { nb_parcelles: 10, surface: 50, SAU: 40 },
+    },
+    surface_agricole_ppe: null,
+    surface_agricole_ppr: null,
+    surface_agricole_bio: {
+      nb_parcelles: 5,
+      surface: 30,
+      part_bio: 25,
+      evolution: [{ annee: 2023, nb_parcelles: 4, surface: 28 }],
+    },
+    culture_evolution: null,
+    installations: [
+      {
+        code: 'INST1',
+        nom: 'Installation 1',
+        code_bss: 'BSS001',
+        commune: 'Commune A',
+        departement: '01',
+        type: 'Forage',
+        nature: 'Souterrain',
+        usage: 'AEP',
+        etat: 'Actif',
+        code_ppe: 'PPE1',
+        prioritaire: true,
+        captages_rattaches: [
+          { code: 'CAP1', nom: 'Captage 1', code_bss: 'BSS_CAP1', etat: 'Actif' },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function createMockAacService(fixture: AacJson | null): AacService {
+  return {
+    getByCode: async () => (fixture ? (fixture as unknown as Record<string, unknown>) : null),
+    getAnalysesRobinetYears: async () => ['2024', '2023'],
+    getAnalysesRobinet: async (_code: string, year: number) => [
+      { date_prelevement: `${year}-03-15`, parametre: 'Nitrates', valeur: 42 },
+    ],
+  } as unknown as AacService
+}
+
+test.group('AacCsvService - exportInfoGenerale', () => {
+  test('returns null when AAC not found', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(null))
+    const result = await service.exportInfoGenerale('99999')
+    assert.isNull(result)
+  })
+
+  test('output starts with UTF-8 BOM', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture()))
+    const csv = await service.exportInfoGenerale('12345')
+    assert.isTrue(csv!.startsWith(BOM))
+  })
+
+  test('contains general info headers', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture()))
+    const csv = await service.exportInfoGenerale('12345')
+    assert.include(csv!, '"Code"')
+    assert.include(csv!, '"Surface (ha)"')
+    assert.include(csv!, '"Date MAJ"')
+  })
+
+  test('contains prioritaire as Oui when true', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture({ prioritaire: true })))
+    const csv = await service.exportInfoGenerale('12345')
+    const rows = parseRows(csv!)
+    const dataRow = rows[1]
+    assert.include(dataRow, '"Oui"')
+  })
+
+  test('contains prioritaire as Non when false', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture({ prioritaire: false })))
+    const csv = await service.exportInfoGenerale('12345')
+    const rows = parseRows(csv!)
+    const dataRow = rows[1]
+    assert.include(dataRow, '"Non"')
+  })
+})
+
+test.group('AacCsvService - exportCaptages', () => {
+  test('returns null when AAC not found', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(null))
+    const result = await service.exportCaptages('99999')
+    assert.isNull(result)
+  })
+
+  test('contains captage headers', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture()))
+    const csv = await service.exportCaptages('12345')
+    assert.include(csv!, '"Code BSS"')
+    assert.include(csv!, '"Captage rattaché - Code"')
+  })
+
+  test('includes installation and captage rattaché data', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture()))
+    const csv = await service.exportCaptages('12345')
+    assert.include(csv!, '"INST1"')
+    assert.include(csv!, '"CAP1"')
+    assert.include(csv!, '"Captage 1"')
+  })
+
+  test('outputs empty fields when no captages rattachés', async ({ assert }) => {
+    const fixture = buildAacFixture({
+      installations: [
+        {
+          code: 'INST2',
+          nom: 'Installation 2',
+          code_bss: 'BSS002',
+          commune: 'Commune B',
+          departement: '02',
+          type: 'Source',
+          nature: 'Surface',
+          usage: 'AEP',
+          etat: 'Actif',
+          code_ppe: 'PPE2',
+          prioritaire: false,
+          captages_rattaches: [],
+        },
+      ],
+    })
+    const service = new AacCsvService(createMockAacService(fixture))
+    const csv = await service.exportCaptages('12345')
+    const rows = parseRows(csv!)
+    const dataRow = rows[1]
+    const fields = parseFields(dataRow)
+    assert.equal(fields[fields.length - 1], '""')
+    assert.equal(fields[fields.length - 2], '""')
+  })
+})
+
+test.group('AacCsvService - exportAssolement', () => {
+  test('returns null when AAC not found', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(null))
+    const result = await service.exportAssolement('99999')
+    assert.isNull(result)
+  })
+
+  test('contains assolement headers', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture()))
+    const csv = await service.exportAssolement('12345')
+    assert.include(csv!, '"Zone"')
+    assert.include(csv!, '"Culture"')
+    assert.include(csv!, '"SAU (%)"')
+  })
+
+  test('includes SAU zone data', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture()))
+    const csv = await service.exportAssolement('12345')
+    assert.include(csv!, 'SAU (Surface Agricole Utile)')
+    assert.include(csv!, '"Blé"')
+  })
+
+  test('includes bio data', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture()))
+    const csv = await service.exportAssolement('12345')
+    assert.include(csv!, 'Bio (global)')
+    assert.include(csv!, 'Bio (évolution)')
+  })
+
+  test('includes culture evolution section when present', async ({ assert }) => {
+    const fixture = buildAacFixture({
+      culture_evolution: {
+        aac: '12345',
+        nom: 'AAC Test',
+        repartition: {
+          Blé: { '2023': { surface_ha: 50, nb_parcelles: 10 } },
+        },
+      },
+    })
+    const service = new AacCsvService(createMockAacService(fixture))
+    const csv = await service.exportAssolement('12345')
+    assert.include(csv!, '"2023"')
+  })
+})
+
+test.group('AacCsvService - exportQualiteEau', () => {
+  test('returns null when AAC not found', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(null))
+    const result = await service.exportQualiteEau('99999')
+    assert.isNull(result)
+  })
+
+  test('returns null when no analyses available', async ({ assert }) => {
+    const mockService = {
+      getByCode: async () => buildAacFixture() as unknown as Record<string, unknown>,
+      getAnalysesRobinetYears: async () => [],
+      getAnalysesRobinet: async () => [],
+    } as unknown as AacService
+    const service = new AacCsvService(mockService)
+    const result = await service.exportQualiteEau('12345')
+    assert.isNull(result)
+  })
+
+  test('contains analyses data from all years', async ({ assert }) => {
+    const service = new AacCsvService(createMockAacService(buildAacFixture()))
+    const csv = await service.exportQualiteEau('12345')
+    assert.isNotNull(csv)
+    assert.include(csv!, '"INST1"')
+    assert.include(csv!, '"42"')
+  })
+
+  test('continues gracefully when getAnalysesRobinetYears throws', async ({ assert }) => {
+    const mockService = {
+      getByCode: async () => buildAacFixture() as unknown as Record<string, unknown>,
+      getAnalysesRobinetYears: async () => {
+        throw new Error('S3 error')
+      },
+      getAnalysesRobinet: async () => [],
+    } as unknown as AacService
+    const service = new AacCsvService(mockService)
+    const result = await service.exportQualiteEau('12345')
+    assert.isNull(result)
+  })
+
+  test('continues gracefully when getAnalysesRobinet throws', async ({ assert }) => {
+    const mockService = {
+      getByCode: async () => buildAacFixture() as unknown as Record<string, unknown>,
+      getAnalysesRobinetYears: async () => ['2024'],
+      getAnalysesRobinet: async () => {
+        throw new Error('S3 error')
+      },
+    } as unknown as AacService
+    const service = new AacCsvService(mockService)
+    const result = await service.exportQualiteEau('12345')
+    assert.isNull(result)
+  })
+})


### PR DESCRIPTION
Cette PR ajoute la possibilité d'exporter les données liées aux Aires de captage (AACs) au format CSV.

Viz'eau a pour but d'aider à la visualisation des données publiques d'assolement et de qualité de l'eau, mais les animateurs ont déjà leurs habitudes via d'autres outils. Dans un souci d'intéropérabilité et d'accompagnement au changement, cette PR leur permet d'aller plus loin en les laissant télécharger les données brutes dans un format facilement adaptable à tous les outils, notamment les tableurs.

Les données exportables sont: 

- Informations générales
- Captages
- Assolement
- Évolution des cultures
- Qualité de l'eau

<img width="1525" height="951" alt="image" src="https://github.com/user-attachments/assets/8a4a39e9-5d1b-44d6-acce-fe3958d89235" />

Closes #326 