### PR TITLE
Correction des champs autocomplete

### DIFF
--- a/inertia/components/aacs/aacs-search.tsx
+++ b/inertia/components/aacs/aacs-search.tsx
@@ -18,6 +18,10 @@ export type AacsSearchProps = {
 
 export default function AacsSearch({ queryString, reloadOnly }: AacsSearchProps) {
   const [isFiltersVisible, setIsFiltersVisible] = useState(false)
+
+  // The inputs are initialized from the URL once, then kept fully local.
+  // This prevents a late Inertia response from overwriting what the user
+  // is still typing.
   const [searchValue, setSearchValue] = useState(queryString?.aacRecherche || '')
   const [communeFilter, setCommuneFilter] = useState(queryString?.aacCommune || '')
 
@@ -44,14 +48,6 @@ export default function AacsSearch({ queryString, reloadOnly }: AacsSearchProps)
       }, 300),
     [reloadOnly]
   )
-
-  useEffect(() => {
-    setSearchValue(queryString?.aacRecherche || '')
-  }, [queryString?.aacRecherche])
-
-  useEffect(() => {
-    setCommuneFilter(queryString?.aacCommune || '')
-  }, [queryString?.aacCommune])
 
   useEffect(() => {
     return () => {

--- a/inertia/components/search-adresse.tsx
+++ b/inertia/components/search-adresse.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import SearchAutocomplete from './search-autocomplete'
 import { debounce } from 'lodash-es'
 
@@ -25,19 +25,34 @@ export default function SearchAdresse({
 }) {
   const [options, setOptions] = useState([])
 
-  const fetchAdresses = debounce(async (search) => {
-    if (search.length > 3) {
-      try {
-        const response = await fetch(`https://data.geopf.fr/geocodage/search?q=${search}&limit=5`)
-        const data = await response.json()
+  const fetchAdresses = useMemo(
+    () =>
+      debounce(async (search: string) => {
+        if (search.length > 3) {
+          try {
+            const response = await fetch(
+              `https://data.geopf.fr/geocodage/search?q=${search}&limit=5`
+            )
+            const data = await response.json()
 
-        setOptions(data.features)
-      } catch (error) {
-        console.error(error)
+            setOptions(data.features)
+          } catch (error) {
+            console.error(error)
+            setOptions([])
+          }
+          return
+        }
+
         setOptions([])
-      }
+      }, 300),
+    []
+  )
+
+  useEffect(() => {
+    return () => {
+      fetchAdresses.cancel()
     }
-  }, 300)
+  }, [fetchAdresses])
 
   return (
     <SearchAutocomplete

--- a/inertia/components/search-adresse.tsx
+++ b/inertia/components/search-adresse.tsx
@@ -31,7 +31,7 @@ export default function SearchAdresse({
         if (search.length > 3) {
           try {
             const response = await fetch(
-              `https://data.geopf.fr/geocodage/search?q=${search}&limit=5`
+              `https://data.geopf.fr/geocodage/search?q=${encodeURIComponent(search)}&limit=5`
             )
             const data = await response.json()
 

--- a/inertia/components/search-autocomplete.tsx
+++ b/inertia/components/search-autocomplete.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { fr } from '@codegouvfr/react-dsfr'
 import { Input } from '@codegouvfr/react-dsfr/Input'
@@ -43,6 +43,10 @@ export default function SearchAutocomplete<T>({
   const [filteredOptions, setFilteredOptions] = useState<T[]>([])
   const containerRef = useRef<HTMLDivElement>(null)
 
+  const selectedValueKeyRef = useRef<string | number | null>(
+    value ? (getOptionKey ? getOptionKey(value) : getOptionLabel(value)) : null
+  )
+
   useEffect(() => {
     const filtered = disableClientFilter
       ? options
@@ -62,6 +66,19 @@ export default function SearchAutocomplete<T>({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
+  useEffect(() => {
+    const nextSelectedKey = value
+      ? getOptionKey
+        ? getOptionKey(value)
+        : getOptionLabel(value)
+      : null
+
+    if (nextSelectedKey !== selectedValueKeyRef.current) {
+      selectedValueKeyRef.current = nextSelectedKey
+      setInputValue(value ? getOptionLabel(value) : '')
+    }
+  }, [value, getOptionKey, getOptionLabel])
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value
     setInputValue(newValue)
@@ -70,6 +87,7 @@ export default function SearchAutocomplete<T>({
   }
 
   const handleOptionClick = (option: T) => {
+    selectedValueKeyRef.current = getOptionKey ? getOptionKey(option) : getOptionLabel(option)
     setInputValue(getOptionLabel(option))
     setIsOpen(false)
     onChange?.(option)

--- a/inertia/components/search-raison-sociale.tsx
+++ b/inertia/components/search-raison-sociale.tsx
@@ -43,7 +43,7 @@ export default function SearchRaisonSociale({
 
           try {
             const response = await fetch(
-              `https://recherche-entreprises.api.gouv.fr/search?q=${search}`,
+              `https://recherche-entreprises.api.gouv.fr/search?q=${encodeURIComponent(search)}`,
               { signal: controller.signal }
             )
 
@@ -56,7 +56,7 @@ export default function SearchRaisonSociale({
             setOptions(data.results)
           } catch (error) {
             // Ignore request abortion errors
-            if (error instanceof Error && error.name === 'AbortError') {
+            if (error?.name === 'AbortError') {
               return
             }
             console.error(error)

--- a/inertia/components/search-raison-sociale.tsx
+++ b/inertia/components/search-raison-sociale.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { debounce } from 'lodash-es'
 import { fr } from '@codegouvfr/react-dsfr'
 import SearchAutocomplete from './search-autocomplete'
@@ -30,38 +30,52 @@ export default function SearchRaisonSociale({
   const [options, setOptions] = useState<RaisonSociale[]>([])
   const abortRef = useRef<AbortController | null>(null)
 
-  const fetchCompanies = debounce(async (search) => {
-    if (search.length > 2) {
-      // Abort the previous request to avoid that too many requests are fired
-      if (abortRef.current) {
-        abortRef.current.abort()
-      }
-      const controller = new AbortController()
-      abortRef.current = controller
+  const fetchCompanies = useMemo(
+    () =>
+      debounce(async (search: string) => {
+        if (search.length > 2) {
+          // Abort the previous request to avoid that too many requests are fired
+          if (abortRef.current) {
+            abortRef.current.abort()
+          }
+          const controller = new AbortController()
+          abortRef.current = controller
 
-      try {
-        const response = await fetch(
-          `https://recherche-entreprises.api.gouv.fr/search?q=${search}`,
-          { signal: controller.signal }
-        )
+          try {
+            const response = await fetch(
+              `https://recherche-entreprises.api.gouv.fr/search?q=${search}`,
+              { signal: controller.signal }
+            )
 
-        if (!response.ok) {
-          const dataText = await response.text()
-          throw new Error(`Erreur API: ${response.status} (${dataText})`)
-        }
+            if (!response.ok) {
+              const dataText = await response.text()
+              throw new Error(`Erreur API: ${response.status} (${dataText})`)
+            }
 
-        const data = await response.json()
-        setOptions(data.results)
-      } catch (error) {
-        // Ignore request abortion errors
-        if (error.name === 'AbortError') {
+            const data = await response.json()
+            setOptions(data.results)
+          } catch (error) {
+            // Ignore request abortion errors
+            if (error instanceof Error && error.name === 'AbortError') {
+              return
+            }
+            console.error(error)
+            setOptions([])
+          }
           return
         }
-        console.error(error)
+
         setOptions([])
-      }
+      }, 400),
+    []
+  )
+
+  useEffect(() => {
+    return () => {
+      fetchCompanies.cancel()
+      abortRef.current?.abort()
     }
-  }, 400)
+  }, [fetchCompanies])
 
   return (
     <SearchAutocomplete<RaisonSociale>


### PR DESCRIPTION
Cette PR corrige des bugs liés aux champs texte avec auto-complétion, notamment de recherche d'adresse ou d'entreprises :

- Lorsqu'on tapait du texte rapidement sans attendre le retour de la requête réseau, le texte pouvait être effacé et revenir à l'état où il était au lancement de la requête.
- Dans certains cas, les requêtes en cours n'étaient pas annulées lorsqu'une nouvelle requête était lancée, ce qui pouvait mener à une *race condition*. 

Closes #384 