### PR TITLE
Ajout du composant UI CheckboxCard

### DIFF
--- a/inertia/ui/CheckboxCard/checkbox-card.css
+++ b/inertia/ui/CheckboxCard/checkbox-card.css
@@ -1,0 +1,17 @@
+.checkbox-card-effect {
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  transition:
+    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.3s ease,
+    filter 0.3s ease;
+  will-change: transform;
+}
+
+.checkbox-card-effect:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 8px 16px rgba(0, 0, 0, 0.15),
+    0 2px 8px rgba(150, 150, 150, 0.1);
+  filter: brightness(0.96);
+}

--- a/inertia/ui/CheckboxCard/checkbox-card.stories.tsx
+++ b/inertia/ui/CheckboxCard/checkbox-card.stories.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import type { Meta } from '@storybook/react'
+import CheckboxCard, { CheckboxCardProps } from './index.js'
+
+const meta: Meta<typeof CheckboxCard> = {
+  title: 'UI/CheckboxCard',
+  component: CheckboxCard,
+  tags: ['autodocs'],
+  decorators: [
+    (Story, context) => {
+      const [isSelected, setIsSelected] = useState(false)
+      return (
+        <Story
+          args={{
+            ...context.args,
+            isSelected,
+            onCheck: () => setIsSelected((v) => !v),
+          }}
+        />
+      )
+    },
+  ],
+  argTypes: {
+    value: {
+      control: 'text',
+      description:
+        'La valeur associée à la carte, utilisée pour identifier la carte lors de la sélection',
+    },
+    title: { control: 'text', description: 'Titre principal affiché sur la carte' },
+    subtitle: { control: 'text', description: 'Sous-titre optionnel affiché sous le titre' },
+    iconId: {
+      control: 'text',
+      description: "Identifiant de l'icône DSFR à afficher (ex: fr-icon-collage-fill)",
+    },
+    metas: {
+      control: 'object',
+      description:
+        'Liste de métadonnées affichées en bas de la carte, chacune avec un contenu et une icône optionnelle',
+    },
+    isSelected: { control: 'boolean', description: 'Indique si la carte est sélectionnée' },
+    onCheck: {
+      action: 'checked',
+      description: 'Callback appelé lorsque la case est cochée ou décochée',
+    },
+  },
+  args: {
+    value: 'checkbox-card-1',
+    title: 'Titre de la carte',
+    subtitle: 'Sous-titre de la carte',
+    iconId: 'fr-icon-submersion-line',
+    metas: [
+      { content: 'Meta 1', iconId: 'fr-icon-user-line' },
+      { content: 'Meta 2', iconId: 'fr-icon-calendar-line' },
+    ],
+    isSelected: false,
+    onCheck: () => {},
+  } as CheckboxCardProps,
+}
+
+export default meta
+
+export const Défaut = {}
+
+export const SansIcone = {
+  args: {
+    iconId: undefined,
+  },
+}
+
+export const SansSousTitre = {
+  args: {
+    subtitle: undefined,
+  },
+}
+
+export const SansMetas = {
+  args: {
+    metas: undefined,
+  },
+}

--- a/inertia/ui/CheckboxCard/index.tsx
+++ b/inertia/ui/CheckboxCard/index.tsx
@@ -26,13 +26,8 @@ export default function CheckboxCard({
   onCheck,
 }: CheckboxCardProps) {
   return (
-    <div
+    <label
       className="checkbox-card-effect flex flex-col gap-3 w-full fr-p-1w cursor-pointer"
-      onClick={(e) => {
-        if ((e.target as HTMLElement).tagName !== 'INPUT' && onCheck) {
-          onCheck(value, !isSelected)
-        }
-      }}
       style={{
         border: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
         backgroundColor: fr.colors.decisions.background.default.grey.default,
@@ -76,13 +71,13 @@ export default function CheckboxCard({
               nativeInputProps: {
                 name: value,
                 value: value,
-                // onChange: onCheck ? (e) => onCheck(e.target.value, e.target.checked) : undefined,
                 checked: isSelected,
+                onChange: () => onCheck && onCheck(value, !isSelected),
               },
             },
           ]}
         />
       </div>
-    </div>
+    </label>
   )
 }

--- a/inertia/ui/CheckboxCard/index.tsx
+++ b/inertia/ui/CheckboxCard/index.tsx
@@ -4,6 +4,8 @@ import TruncatedText from '../TruncatedText'
 import MetasList, { MetasListProps } from '../MetasList'
 import { Checkbox } from '@codegouvfr/react-dsfr/Checkbox'
 
+import './checkbox-card.css'
+
 export type CheckboxCardProps = {
   value: string
   title: string
@@ -25,7 +27,12 @@ export default function CheckboxCard({
 }: CheckboxCardProps) {
   return (
     <div
-      className="flex flex-col gap-3 w-full fr-p-1w"
+      className="checkbox-card-effect flex flex-col gap-3 w-full fr-p-1w cursor-pointer"
+      onClick={(e) => {
+        if ((e.target as HTMLElement).tagName !== 'INPUT' && onCheck) {
+          onCheck(value, !isSelected)
+        }
+      }}
       style={{
         border: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
         backgroundColor: fr.colors.decisions.background.default.grey.default,
@@ -65,13 +72,12 @@ export default function CheckboxCard({
         <Checkbox
           options={[
             {
-              label: '',
+              label: <span className="fr-sr-only">{title}</span>,
               nativeInputProps: {
-                'name': value,
-                'value': value,
-                'aria-label': title,
-                'onChange': onCheck ? (e) => onCheck(e.target.value, e.target.checked) : undefined,
-                'checked': isSelected,
+                name: value,
+                value: value,
+                // onChange: onCheck ? (e) => onCheck(e.target.value, e.target.checked) : undefined,
+                checked: isSelected,
               },
             },
           ]}

--- a/inertia/ui/CheckboxCard/index.tsx
+++ b/inertia/ui/CheckboxCard/index.tsx
@@ -2,7 +2,7 @@ import { fr } from '@codegouvfr/react-dsfr'
 
 import TruncatedText from '../TruncatedText'
 import MetasList, { MetasListProps } from '../MetasList'
-import Checkbox from '@codegouvfr/react-dsfr/Checkbox'
+import { Checkbox } from '@codegouvfr/react-dsfr/Checkbox'
 
 export type CheckboxCardProps = {
   value: string
@@ -11,7 +11,7 @@ export type CheckboxCardProps = {
   iconId?: string
   metas?: MetasListProps['metas']
   isSelected?: boolean
-  onCheck?: (value: string) => void
+  onCheck?: (value: string, checked: boolean) => void
 }
 
 export default function CheckboxCard({
@@ -67,10 +67,11 @@ export default function CheckboxCard({
             {
               label: '',
               nativeInputProps: {
-                name: value,
-                value: value,
-                onChange: onCheck ? (e) => onCheck(e.target.value) : undefined,
-                checked: isSelected,
+                'name': value,
+                'value': value,
+                'aria-label': title,
+                'onChange': onCheck ? (e) => onCheck(e.target.value, e.target.checked) : undefined,
+                'checked': isSelected,
               },
             },
           ]}

--- a/inertia/ui/CheckboxCard/index.tsx
+++ b/inertia/ui/CheckboxCard/index.tsx
@@ -1,0 +1,81 @@
+import { fr } from '@codegouvfr/react-dsfr'
+
+import TruncatedText from '../TruncatedText'
+import MetasList, { MetasListProps } from '../MetasList'
+import Checkbox from '@codegouvfr/react-dsfr/Checkbox'
+
+export type CheckboxCardProps = {
+  value: string
+  title: string
+  subtitle?: string
+  iconId?: string
+  metas?: MetasListProps['metas']
+  isSelected?: boolean
+  onCheck?: (value: string) => void
+}
+
+export default function CheckboxCard({
+  value,
+  title,
+  subtitle,
+  iconId,
+  metas,
+  isSelected = false,
+  onCheck,
+}: CheckboxCardProps) {
+  return (
+    <div
+      className="flex flex-col gap-3 w-full fr-p-1w"
+      style={{
+        border: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
+        backgroundColor: fr.colors.decisions.background.default.grey.default,
+      }}
+    >
+      <div className="flex gap-2">
+        {iconId && (
+          <div
+            className="flex items-center justify-center w-fit fr-p-1w aspect-square"
+            style={{
+              backgroundColor: fr.colors.decisions.background.flat.blueFrance.default,
+              color: fr.colors.decisions.text.inverted.grey.default,
+            }}
+          >
+            <span className={`${iconId} fr-icon--lg aspect-square`} aria-hidden="true" />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1 w-full">
+          <div className="flex flex-col w-full">
+            <TruncatedText maxLines={1} className="flex-1 fr-m-0 fr-text--lg font-bold">
+              {title}
+            </TruncatedText>
+
+            {subtitle && (
+              <TruncatedText
+                maxLines={1}
+                className="fr-mb-0 fr-text--sm"
+                style={{ color: fr.colors.decisions.text.mention.grey.default }}
+              >
+                {subtitle}
+              </TruncatedText>
+            )}
+          </div>
+          {metas && metas.length > 0 && <MetasList metas={metas} size="xs" />}
+        </div>
+        <Checkbox
+          options={[
+            {
+              label: '',
+              nativeInputProps: {
+                name: value,
+                value: value,
+                onChange: onCheck ? (e) => onCheck(e.target.value) : undefined,
+                checked: isSelected,
+              },
+            },
+          ]}
+        />
+      </div>
+    </div>
+  )
+}

--- a/inertia/ui/LabelInfo/index.tsx
+++ b/inertia/ui/LabelInfo/index.tsx
@@ -5,14 +5,14 @@ export type LabelInfoProps = {
   icon?: string | null
   label?: string
   info?: string | React.ReactNode
-  size?: 'sm' | 'md'
+  size?: 'xs' | 'sm' | 'md'
 }
 export default function LabelInfo({ icon, label, info, size = 'md' }: LabelInfoProps) {
   const isStringInfo = typeof info === 'string'
   const labelText = info && label ? label + ' : ' : label
 
   return (
-    <div className="flex items-start">
+    <div className="flex items-center">
       {icon && (
         <span
           className={`${icon} fr-icon--${size} fr-mr-1v flex-shrink-0`}

--- a/inertia/ui/MetasList/index.tsx
+++ b/inertia/ui/MetasList/index.tsx
@@ -2,7 +2,7 @@ import LabelInfo from '../LabelInfo'
 
 export type MetasListProps = {
   metas: { content: string | null; iconId: string | null }[]
-  size?: 'sm' | 'md'
+  size?: 'xs' | 'sm' | 'md'
 }
 
 export default function MetasList({ metas, size = 'md' }: MetasListProps) {


### PR DESCRIPTION
**Nouveau composant UI :**

* Ajout d’un nouveau composant `CheckboxCard` prenant en charge un titre, un sous-titre, une icône, des métadonnées et un état de sélection. Le composant est entièrement personnalisable via les tokens de couleur DSFR et intègre une case à cocher pour la sélection.
* Création de stories Storybook pour `CheckboxCard`, incluant des variantes sans icône, sans sous-titre ou sans métadonnées, ainsi qu’une sélection interactive via un decorator. 

**Améliorations de composants (gestion des tailles) :**

* Ajout de la prise en charge d’une taille extra small (`xs`) au composant `LabelInfo` et ajustement de son layout avec `items-center` pour un meilleur alignement vertical.
* Extension du composant `MetasList` pour accepter la taille `xs`, permettant un affichage plus compact des métadonnées.

<img width="955" height="240" alt="Capture d’écran 2026-04-24 à 11 29 54" src="https://github.com/user-attachments/assets/a0d333aa-286f-4e5d-bc23-272bc1df0589" />
