### PR TITLE
[Carte] Améliorations sur l'affichage des parcelles 

### DIFF
--- a/inertia/components/map-layer-filters.tsx
+++ b/inertia/components/map-layer-filters.tsx
@@ -18,6 +18,7 @@ export default function MapLayerFilters({
   setShowBioOnly = (_update) => {},
   setShowSage = (_update) => {},
   canSwitchToBioOnly = true,
+  parcellesZoomDisabled = false,
 }: {
   showParcelles?: boolean
   showAac?: boolean
@@ -34,14 +35,26 @@ export default function MapLayerFilters({
   setShowBioOnly?: Dispatch<SetStateAction<boolean>>
   setShowSage?: Dispatch<SetStateAction<boolean>>
   canSwitchToBioOnly?: boolean
+  parcellesZoomDisabled?: boolean
 }) {
   return (
     <div className="flex flex-col gap-1">
       <LegendItem
         label="Parcelles"
-        hint="Terrains cadastrés"
+        hint={
+          parcellesZoomDisabled
+            ? 'Zoomez davantage pour afficher les parcelles'
+            : 'Terrains cadastrés'
+        }
         checked={showParcelles}
+        disabled={parcellesZoomDisabled}
         onChange={() => setShowParcelles((prev) => !prev)}
+      />
+      <LegendItem
+        label="Parcelles bio uniquement"
+        checked={showBioOnly}
+        disabled={!showParcelles || !canSwitchToBioOnly || parcellesZoomDisabled}
+        onChange={() => setShowBioOnly((prev) => !prev)}
       />
       <LegendItem
         label="AAC"
@@ -75,12 +88,6 @@ export default function MapLayerFilters({
         label="Délimitations des communes"
         checked={showCommunes}
         onChange={() => setShowCommunes((prev) => !prev)}
-      />
-      <LegendItem
-        label="Parcelles bio uniquement"
-        checked={showBioOnly}
-        disabled={!showParcelles || !canSwitchToBioOnly}
-        onChange={() => setShowBioOnly((prev) => !prev)}
       />
     </div>
   )

--- a/inertia/components/map/VisualisationMap.tsx
+++ b/inertia/components/map/VisualisationMap.tsx
@@ -91,6 +91,7 @@ const VisualisationMap = forwardRef<
     visibleCultures?: string[]
     showSage?: boolean
     style?: string
+    onZoomChange?: (zoom: number) => void
   }
 >(
   (
@@ -118,6 +119,7 @@ const VisualisationMap = forwardRef<
       visibleCultures = [],
       showSage = false,
       style = 'vector',
+      onZoomChange,
     },
     ref
   ) => {
@@ -135,6 +137,11 @@ const VisualisationMap = forwardRef<
     const currentStyleRef = useRef<string>('vector')
     const previousVisibleCulturesRef = useRef<string[]>([])
     const showBioOnlyRef = useRef(false)
+    const onZoomChangeRef = useRef(onZoomChange)
+
+    useEffect(() => {
+      onZoomChangeRef.current = onZoomChange
+    }, [onZoomChange])
 
     // Synchroniser les refs avec les props
     useEffect(() => {
@@ -401,6 +408,10 @@ const VisualisationMap = forwardRef<
       // Ensures the map is not blocked in loading state after any loading event
       map.on('idle', () => {
         setIsMapLoading(false)
+      })
+
+      map.on('zoomend', () => {
+        onZoomChangeRef.current?.(map.getZoom())
       })
 
       mapRef.current = map

--- a/inertia/components/map/VisualisationMap.tsx
+++ b/inertia/components/map/VisualisationMap.tsx
@@ -137,11 +137,6 @@ const VisualisationMap = forwardRef<
     const currentStyleRef = useRef<string>('vector')
     const previousVisibleCulturesRef = useRef<string[]>([])
     const showBioOnlyRef = useRef(false)
-    const onZoomChangeRef = useRef(onZoomChange)
-
-    useEffect(() => {
-      onZoomChangeRef.current = onZoomChange
-    }, [onZoomChange])
 
     // Synchroniser les refs avec les props
     useEffect(() => {
@@ -402,7 +397,7 @@ const VisualisationMap = forwardRef<
         addLayers(getSageLayer(), beforeId)
         addLayers(getParcellesLayers(), beforeId)
 
-        onZoomChangeRef.current?.(map.getZoom())
+        onZoomChange?.(map.getZoom())
         setIsMapLoading(false)
       })
 
@@ -412,7 +407,7 @@ const VisualisationMap = forwardRef<
       })
 
       map.on('zoomend', () => {
-        onZoomChangeRef.current?.(map.getZoom())
+        onZoomChange?.(map.getZoom())
       })
 
       mapRef.current = map

--- a/inertia/components/map/VisualisationMap.tsx
+++ b/inertia/components/map/VisualisationMap.tsx
@@ -402,6 +402,7 @@ const VisualisationMap = forwardRef<
         addLayers(getSageLayer(), beforeId)
         addLayers(getParcellesLayers(), beforeId)
 
+        onZoomChangeRef.current?.(map.getZoom())
         setIsMapLoading(false)
       })
 

--- a/inertia/components/map/styles/parcelles.tsx
+++ b/inertia/components/map/styles/parcelles.tsx
@@ -26,7 +26,7 @@ export const getParcellesLayers = (): LayerSpecification[] => {
       'type': 'fill',
       'source': 'parcelles',
       'source-layer': 'parcelles',
-      'minzoom': 12,
+      'minzoom': 10,
       'paint': {
         'fill-color': colorMatch as any,
         'fill-opacity': [
@@ -44,7 +44,7 @@ export const getParcellesLayers = (): LayerSpecification[] => {
       'type': 'line',
       'source': 'parcelles',
       'source-layer': 'parcelles',
-      'minzoom': 12,
+      'minzoom': 10,
       'paint': {
         'line-color': '#000000',
         'line-width': [
@@ -74,7 +74,7 @@ export const getParcellesLayers = (): LayerSpecification[] => {
       'type': 'fill',
       'source': 'parcelles',
       'source-layer': 'parcellesbio',
-      'minzoom': 12,
+      'minzoom': 10,
       'paint': {
         'fill-color': colorMatch as any,
         'fill-opacity': 0, // Transparent par défaut pour la détection uniquement
@@ -85,7 +85,7 @@ export const getParcellesLayers = (): LayerSpecification[] => {
       'type': 'line',
       'source': 'parcelles',
       'source-layer': 'parcellesbio',
-      'minzoom': 12,
+      'minzoom': 10,
       'paint': {
         'line-color': '#000000',
         'line-width': ['interpolate', ['linear'], ['zoom'], 15, 1, 18, 3],

--- a/inertia/components/visualisation-right-side-bar.tsx
+++ b/inertia/components/visualisation-right-side-bar.tsx
@@ -18,6 +18,7 @@ export default function VisualisationRightSideBar({
   setShowBioOnly = (_update: boolean | ((prev: boolean) => boolean)) => {},
   setShowSage = (_update: boolean | ((prev: boolean) => boolean)) => {},
   canSwitchToBioOnly = true,
+  parcellesZoomDisabled = false,
   visibleCultures,
   onToggleCulture,
   onToggleAllCultures,
@@ -37,6 +38,7 @@ export default function VisualisationRightSideBar({
   setShowBioOnly?: (update: boolean | ((prev: boolean) => boolean)) => void
   setShowSage?: (update: boolean | ((prev: boolean) => boolean)) => void
   canSwitchToBioOnly?: boolean
+  parcellesZoomDisabled?: boolean
   visibleCultures?: string[]
   onToggleCulture?: (code: string) => void
   onToggleAllCultures?: () => void
@@ -65,6 +67,7 @@ export default function VisualisationRightSideBar({
           showSage={showSage}
           setShowSage={setShowSage}
           canSwitchToBioOnly={canSwitchToBioOnly}
+          parcellesZoomDisabled={parcellesZoomDisabled}
         />
       </SmallSection>
 

--- a/inertia/pages/visualisation.tsx
+++ b/inertia/pages/visualisation.tsx
@@ -42,7 +42,7 @@ export default function VisualisationPage({
   selectedAac,
 }: InferPageProps<VisualisationController, 'index'>) {
   const [isMapLoading, setIsMapLoading] = useState(true)
-  const [mapZoom, setMapZoom] = useState(5)
+  const [mapZoom, setMapZoom] = useState<number | null>(null)
   const [showParcelles, setShowParcelles] = useState(true)
   const [showAac, setShowAac] = useState(true)
   const [showPpe, setShowPpe] = useState(false)
@@ -395,7 +395,7 @@ export default function VisualisationPage({
             showSage={showSage}
             setShowSage={() => setShowSage((prev) => !prev)}
             canSwitchToBioOnly={!editMode}
-            parcellesZoomDisabled={mapZoom < 10}
+            parcellesZoomDisabled={mapZoom !== null && mapZoom < 10}
             visibleCultures={visibleCultures}
             onToggleCulture={toggleCulture}
             onToggleAllCultures={toggleAllCultures}

--- a/inertia/pages/visualisation.tsx
+++ b/inertia/pages/visualisation.tsx
@@ -42,6 +42,7 @@ export default function VisualisationPage({
   selectedAac,
 }: InferPageProps<VisualisationController, 'index'>) {
   const [isMapLoading, setIsMapLoading] = useState(true)
+  const [mapZoom, setMapZoom] = useState(5)
   const [showParcelles, setShowParcelles] = useState(true)
   const [showAac, setShowAac] = useState(true)
   const [showPpe, setShowPpe] = useState(false)
@@ -374,6 +375,7 @@ export default function VisualisationPage({
             ref={mapRef}
             visibleCultures={visibleCultures}
             style={style}
+            onZoomChange={setMapZoom}
           />
         }
         rightContent={
@@ -393,6 +395,7 @@ export default function VisualisationPage({
             showSage={showSage}
             setShowSage={() => setShowSage((prev) => !prev)}
             canSwitchToBioOnly={!editMode}
+            parcellesZoomDisabled={mapZoom < 10}
             visibleCultures={visibleCultures}
             onToggleCulture={toggleCulture}
             onToggleAllCultures={toggleAllCultures}


### PR DESCRIPTION
Cette PR modifie le zoom initial sur les parcelles, afin qu'elles soient affichées à un niveau de zoom plus bas.
Lorsque les parcelles ne sont pas affichées, les checkbox permettant d'afficher / masquer les parcelles sont grisées et une infobulle est affichée afin d'indiquer à l'utilisateur qu'il faut zoomer pour les voir.

## Capture : 

https://github.com/user-attachments/assets/78bfaaec-06d5-4243-9b1f-596867337873

Fix #264 