### PR TITLE
Augmente zindex pour passer au dessus des controles de la carte

### DIFF
--- a/inertia/components/search-autocomplete.tsx
+++ b/inertia/components/search-autocomplete.tsx
@@ -130,7 +130,7 @@ export default function SearchAutocomplete<T>({
             left: 0,
             border: '1px solid var(--border-default-grey)',
             pointerEvents: 'auto',
-            zIndex: 1,
+            zIndex: 3,
           }}
           role="listbox"
         >


### PR DESCRIPTION
### Avant : 

<img width="1552" height="980" alt="image" src="https://github.com/user-attachments/assets/50f1d812-9787-43b1-a4bf-5308c5c61765" />

### Après : 

<img width="1552" height="980" alt="image" src="https://github.com/user-attachments/assets/9bf5963e-0424-48fc-9572-7ea8023f41e1" />
