### PR TITLE
Toaster de confirmation lors de l'attribution des parcelles

### DIFF
--- a/app/services/aac_service.ts
+++ b/app/services/aac_service.ts
@@ -631,7 +631,6 @@ export class AacService {
     }
   }
 
-
   async getAnalysesRobinetForExport(
     installationCodes: string[]
   ): Promise<Record<string, unknown>[]> {
@@ -644,9 +643,9 @@ export class AacService {
 
     const stmt = await conn.prepare(
       'SELECT "code_insee", "nom_commune", "code_installation", "nom_installation", "date_prelevement", "heure_prelevement", "code_brgm", "resultat", "code_unite", "libelle_parametre", "limite_qualite", "reference_qualite", "captage_prioritaire" ' +
-      'FROM read_parquet($1) ' +
-      `WHERE "code_installation" IN (${placeholders}) ` +
-      'ORDER BY "date_prelevement" DESC NULLS LAST'
+        'FROM read_parquet($1) ' +
+        `WHERE "code_installation" IN (${placeholders}) ` +
+        'ORDER BY "date_prelevement" DESC NULLS LAST'
     )
 
     stmt.bindVarchar(1, getAnalysesRobinetPath())

--- a/inertia/components/parcelles-manager.tsx
+++ b/inertia/components/parcelles-manager.tsx
@@ -1,7 +1,9 @@
 import Button from '@codegouvfr/react-dsfr/Button'
 import { createModal } from '@codegouvfr/react-dsfr/Modal'
 import { fr } from '@codegouvfr/react-dsfr'
+import { toast } from 'react-toastify'
 import Loader from '~/ui/Loader'
+import Toast from '~/ui/Toaster'
 import { ExploitationJson } from '../../types/models'
 
 export type ParcellesManagerProps = {
@@ -15,7 +17,7 @@ export type ParcellesManagerProps = {
   isDirty: boolean
   processing: boolean
   reset: (...args: unknown[]) => void
-  sendFormAndResetState: (...args: unknown[]) => void
+  sendFormAndResetState: (onAfterSuccess?: () => void) => void
 }
 
 export default function ParcellesManager({
@@ -35,6 +37,20 @@ export default function ParcellesManager({
     id: 'cancel-edit-mode-modal',
     isOpenedByDefault: false,
   })
+  const showSuccessToast = () => {
+    toast(
+      <Toast
+        alerts={[
+          { severity: 'success', message: 'Les parcelles ont été mises à jour avec succès.' },
+        ]}
+      />,
+      {
+        closeButton: false,
+        style: { padding: 0, background: 'transparent', boxShadow: 'none' },
+      }
+    )
+  }
+
   return (
     <div
       className="flex flex-col gap-1"
@@ -72,7 +88,7 @@ export default function ParcellesManager({
               size="small"
               disabled={processing}
               onClick={() => {
-                sendFormAndResetState()
+                sendFormAndResetState(showSuccessToast)
               }}
             >
               Appliquer
@@ -118,7 +134,7 @@ export default function ParcellesManager({
             children: 'Appliquer les modifications',
             disabled: processing,
             onClick: () => {
-              sendFormAndResetState()
+              sendFormAndResetState(showSuccessToast)
             },
           },
         ]}

--- a/inertia/pages/visualisation.tsx
+++ b/inertia/pages/visualisation.tsx
@@ -98,11 +98,12 @@ export default function VisualisationPage({
     parcelles: data.parcelles,
   }))
 
-  const sendFormAndResetState = () => {
+  const sendFormAndResetState = (onAfterSuccess?: () => void) => {
     post(assignParcellesToExploitationUrl, {
       preserveState: true,
       onSuccess: () => {
         setEditMode(false)
+        onAfterSuccess?.()
       },
       // Reload the exploitations to get updated parcelle data
       only: ['filteredExploitations'],

--- a/inertia/ui/Toaster/index.tsx
+++ b/inertia/ui/Toaster/index.tsx
@@ -30,6 +30,7 @@ export default function Toast({ alerts, closeToast }: ToastProps) {
           description={message}
           small
           closable
+          style={{ fontFamily: 'Marianne' }}
           onClose={() => handleAlertClose(message)}
         />
       ))}

--- a/inertia/ui/Toaster/index.tsx
+++ b/inertia/ui/Toaster/index.tsx
@@ -30,7 +30,7 @@ export default function Toast({ alerts, closeToast }: ToastProps) {
           description={message}
           small
           closable
-          style={{ fontFamily: 'Marianne' }}
+          style={{ fontFamily: 'Marianne, arial, sans-serif' }}
           onClose={() => handleAlertClose(message)}
         />
       ))}


### PR DESCRIPTION
Cette PR ajoute une notification en haut de l'écran lorsque l'utilisateur termine l'attribution des parcelles à une exploitation.

## Capture : 


https://github.com/user-attachments/assets/9d4dcc93-6b7e-41b1-897b-ea66ab77f346

<br />
Fix #268