### PR TITLE
Mise à jour du service de recherche d'exploitations

### DIFF
--- a/app/controllers/exploitations_controller.ts
+++ b/app/controllers/exploitations_controller.ts
@@ -63,7 +63,7 @@ export default class ExploitationsController {
     return inertia.render('exploitations/index', {
       // Fetches results, paginate and casts to DTOs
       exploitationsWithPagination: async () => {
-        const results = await this.exploitationService.searchActiveExploitationsByNameOrContactName(
+        const results = await this.exploitationService.searchActiveExploitations(
           request.input('recherche'),
           user.id,
           request.input('page', 1)

--- a/app/controllers/visualisation_controller.ts
+++ b/app/controllers/visualisation_controller.ts
@@ -97,7 +97,7 @@ export default class VisualisationController {
       },
       filteredExploitations: async () => {
         const results = await this.exploitationService
-          .getAllActiveExploitationsByNameOrContactName(request.input('recherche'), user.id)
+          .getAllActiveExploitations(request.input('recherche'), user.id)
           .preload('parcelles', (parcelleQuery) => {
             parcelleQuery.where('year', request.qs().millesime).orderBy('rpgId', 'asc')
           })

--- a/app/services/exploitation_service.ts
+++ b/app/services/exploitation_service.ts
@@ -33,18 +33,36 @@ export class ExploitationService {
   }
 
   /**
-   * Search active exploitations by their name or by the name of their contacts.
+   * Applies a full-text search filter on the given query builder.
+   * Matches against: exploitation name, commune, contact full name, contact email, contact phone number.
+   */
+  private applySearchFilter<T extends ReturnType<typeof this.queryActiveExploitations>>(
+    queryBuilder: T,
+    query: string
+  ): T {
+    return queryBuilder.where((builder) => {
+      builder
+        .where('name', 'ilike', `%${query}%`)
+        .orWhere('commune', 'ilike', `%${query}%`)
+        .orWhereHas('contacts', (contactQuery) => {
+          contactQuery
+            .whereRaw("CONCAT(COALESCE(first_name, ''), ' ', COALESCE(last_name, '')) ILIKE ?", [
+              `%${query}%`,
+            ])
+            .orWhere('email', 'ilike', `%${query}%`)
+            .orWhere('phone_number', 'ilike', `%${query}%`)
+        })
+    }) as T
+  }
+
+  /**
+   * Search active exploitations by name, commune, or contact fields (name, email, phone number).
    * @param query
    * @param userId
    * @param page
    * @param pageSize
    */
-  async searchActiveExploitationsByNameOrContactName(
-    query: string,
-    userId: string,
-    page: number = 1,
-    pageSize = 10
-  ) {
+  async searchActiveExploitations(query: string, userId: string, page: number = 1, pageSize = 10) {
     const queryBuilder = this.queryActiveExploitations(userId)
       .preload('contacts')
       .preload('user')
@@ -55,24 +73,14 @@ export class ExploitationService {
       return queryBuilder.paginate(page, pageSize)
     }
 
-    return queryBuilder
-      .where((builder) => {
-        builder
-          .where('name', 'ilike', `%${query}%`)
-          .orWhere('commune', 'ilike', `%${query}%`)
-          .orWhereHas('contacts', (contactQuery) => {
-            contactQuery
-              .whereRaw("CONCAT(COALESCE(first_name, ''), ' ', COALESCE(last_name, '')) ILIKE ?", [
-                `%${query}%`,
-              ])
-              .orWhere('email', 'ilike', `%${query}%`)
-              .orWhere('phone_number', 'ilike', `%${query}%`)
-          })
-      })
-      .paginate(page, pageSize)
+    return this.applySearchFilter(queryBuilder, query).paginate(page, pageSize)
   }
 
-  getAllActiveExploitationsByNameOrContactName(query: string, userId: string) {
+  /**
+   * Return all active exploitations matching a query on name, commune, or contact fields (name, email, phone number).
+   * Unlike {@link searchActiveExploitations}, this method does not paginate results.
+   */
+  getAllActiveExploitations(query: string, userId: string) {
     const queryBuilder = this.queryActiveExploitations(userId)
       .preload('contacts')
       .preload('user')
@@ -80,19 +88,7 @@ export class ExploitationService {
       .orderBy('updatedAt', 'desc')
 
     if (query) {
-      queryBuilder.where((builder) => {
-        builder
-          .where('name', 'ilike', `%${query}%`)
-          .orWhere('commune', 'ilike', `%${query}%`)
-          .orWhereHas('contacts', (contactQuery) => {
-            contactQuery
-              .whereRaw("CONCAT(COALESCE(first_name, ''), ' ', COALESCE(last_name, '')) ILIKE ?", [
-                `%${query}%`,
-              ])
-              .orWhere('email', 'ilike', `%${query}%`)
-              .orWhere('phone_number', 'ilike', `%${query}%`)
-          })
-      })
+      this.applySearchFilter(queryBuilder, query)
     }
 
     return queryBuilder

--- a/app/services/exploitation_service.ts
+++ b/app/services/exploitation_service.ts
@@ -57,12 +57,17 @@ export class ExploitationService {
 
     return queryBuilder
       .where((builder) => {
-        builder.where('name', 'ilike', `%${query}%`).orWhereHas('contacts', (contactQuery) => {
-          contactQuery.whereRaw(
-            "CONCAT(COALESCE(first_name, ''), ' ', COALESCE(last_name, '')) ILIKE ?",
-            [`%${query}%`]
-          )
-        })
+        builder
+          .where('name', 'ilike', `%${query}%`)
+          .orWhere('commune', 'ilike', `%${query}%`)
+          .orWhereHas('contacts', (contactQuery) => {
+            contactQuery
+              .whereRaw("CONCAT(COALESCE(first_name, ''), ' ', COALESCE(last_name, '')) ILIKE ?", [
+                `%${query}%`,
+              ])
+              .orWhere('email', 'ilike', `%${query}%`)
+              .orWhere('phone_number', 'ilike', `%${query}%`)
+          })
       })
       .paginate(page, pageSize)
   }
@@ -76,12 +81,17 @@ export class ExploitationService {
 
     if (query) {
       queryBuilder.where((builder) => {
-        builder.where('name', 'ilike', `%${query}%`).orWhereHas('contacts', (contactQuery) => {
-          contactQuery.whereRaw(
-            "CONCAT(COALESCE(first_name, ''), ' ', COALESCE(last_name, '')) ILIKE ?",
-            [`%${query}%`]
-          )
-        })
+        builder
+          .where('name', 'ilike', `%${query}%`)
+          .orWhere('commune', 'ilike', `%${query}%`)
+          .orWhereHas('contacts', (contactQuery) => {
+            contactQuery
+              .whereRaw("CONCAT(COALESCE(first_name, ''), ' ', COALESCE(last_name, '')) ILIKE ?", [
+                `%${query}%`,
+              ])
+              .orWhere('email', 'ilike', `%${query}%`)
+              .orWhere('phone_number', 'ilike', `%${query}%`)
+          })
       })
     }
 

--- a/tests/unit/exploitation/exploitation_service.spec.ts
+++ b/tests/unit/exploitation/exploitation_service.spec.ts
@@ -163,13 +163,12 @@ test.group('Exploitation service', (group) => {
 
     const exploitationService = new ExploitationService()
 
-    const emptyQueryResults =
-      await exploitationService.searchActiveExploitationsByNameOrContactName('', user.id)
+    const emptyQueryResults = await exploitationService.searchActiveExploitations('', user.id)
 
     assert.isAtLeast(emptyQueryResults.all().length, 1)
     assert.equal(emptyQueryResults.all()[0].id, exploitation.id)
 
-    const nameQueryResults = await exploitationService.searchActiveExploitationsByNameOrContactName(
+    const nameQueryResults = await exploitationService.searchActiveExploitations(
       exploitationName.toLowerCase().slice(0, 5),
       user.id
     )
@@ -178,17 +177,127 @@ test.group('Exploitation service', (group) => {
     assert.equal(nameQueryResults.all()[0].id, exploitation.id)
 
     // Search by a fragment of the contact name
-    const contactQueryResults =
-      await exploitationService.searchActiveExploitationsByNameOrContactName('lice Smi', user.id)
+    const contactQueryResults = await exploitationService.searchActiveExploitations(
+      'lice Smi',
+      user.id
+    )
 
     assert.isAtLeast(contactQueryResults.all().length, 1)
     assert.equal(contactQueryResults.all()[0].id, exploitation.id)
 
-    const noResults = await exploitationService.searchActiveExploitationsByNameOrContactName(
+    const noResults = await exploitationService.searchActiveExploitations(
       'NonExistingQuery',
       user.id
     )
 
     assert.equal(noResults.all().length, 0)
+  })
+
+  test('I can search exploitations by commune', async ({ assert }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const exploitation = await ExploitationFactory.merge({ commune: 'Montpellier' }).create()
+    await exploitation.related('territoires').attach([territoire.id])
+
+    const exploitationService = new ExploitationService()
+
+    const results = await exploitationService.searchActiveExploitations('montpell', user.id)
+
+    assert.isAtLeast(results.all().length, 1)
+    assert.isTrue(results.all().some((e) => e.id === exploitation.id))
+
+    const noResults = await exploitationService.searchActiveExploitations(
+      'CommuneInexistante',
+      user.id
+    )
+
+    assert.equal(noResults.all().length, 0)
+  })
+
+  test('I can search exploitations by contact email', async ({ assert }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const exploitation = await ExploitationFactory.with('contacts', 1, (contactQuery) => {
+      contactQuery.merge({ email: 'agriculteur@domaine.fr' })
+    }).create()
+    await exploitation.related('territoires').attach([territoire.id])
+
+    const exploitationService = new ExploitationService()
+
+    const results = await exploitationService.searchActiveExploitations(
+      'agriculteur@domaine',
+      user.id
+    )
+
+    assert.isAtLeast(results.all().length, 1)
+    assert.isTrue(results.all().some((e) => e.id === exploitation.id))
+
+    const noResults = await exploitationService.searchActiveExploitations(
+      'email.inexistant@test.fr',
+      user.id
+    )
+
+    assert.equal(noResults.all().length, 0)
+  })
+
+  test('I can search exploitations by contact phone number', async ({ assert }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const exploitation = await ExploitationFactory.with('contacts', 1, (contactQuery) => {
+      contactQuery.merge({ phoneNumber: '0612345678' })
+    }).create()
+    await exploitation.related('territoires').attach([territoire.id])
+
+    const exploitationService = new ExploitationService()
+
+    const results = await exploitationService.searchActiveExploitations('061234', user.id)
+
+    assert.isAtLeast(results.all().length, 1)
+    assert.isTrue(results.all().some((e) => e.id === exploitation.id))
+
+    const noResults = await exploitationService.searchActiveExploitations('0600000000', user.id)
+
+    assert.equal(noResults.all().length, 0)
+  })
+
+  test('I can search exploitations by secondary contact fields', async ({ assert }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const exploitation = await ExploitationFactory.with('contacts', 2, (contactQuery) => {
+      contactQuery.merge([
+        { firstName: 'Primary', lastName: 'Contact', isPrimaryContact: true },
+        {
+          firstName: 'Secondary',
+          lastName: 'Contact',
+          isPrimaryContact: false,
+          email: 'secondary@farm.fr',
+          phoneNumber: '0799887766',
+        },
+      ])
+    }).create()
+    await exploitation.related('territoires').attach([territoire.id])
+
+    const exploitationService = new ExploitationService()
+
+    const emailResults = await exploitationService.searchActiveExploitations(
+      'secondary@farm',
+      user.id
+    )
+
+    assert.isAtLeast(emailResults.all().length, 1)
+    assert.isTrue(emailResults.all().some((e) => e.id === exploitation.id))
+
+    const phoneResults = await exploitationService.searchActiveExploitations('079988', user.id)
+
+    assert.isAtLeast(phoneResults.all().length, 1)
+    assert.isTrue(phoneResults.all().some((e) => e.id === exploitation.id))
   })
 })


### PR DESCRIPTION
Cette PR ajoute des paramètres pour effectuer une recherche d'exploitation.
On peut maintenant rechercher une exploitation à partir : 
- Du nom, prénom, email ou numéro de téléphone d'un des contacts de l'exploitation
- Du nom de la commune de l'exploitation
- Du nom de l'exploitation

Fix #193 