### PR TITLE
Implémentation des modèles et des routes CRUD du module projet

### DIFF
--- a/app/controllers/projects_controller.ts
+++ b/app/controllers/projects_controller.ts
@@ -1,0 +1,62 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import Project from '#models/project'
+import { ProjectService } from '#services/project_service'
+import {
+  createProjectValidator,
+  destroyProjectValidator,
+  updateProjectValidator,
+} from '#validators/project'
+import { ProjectDto } from '../dto/project_dto.js'
+
+@inject()
+export default class ProjectsController {
+  constructor(public projectService: ProjectService) {}
+
+  async index({ auth, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const projects = await Project.query().where('userId', user.id).orderBy('createdAt', 'desc')
+
+    return response.json({
+      data: projects.map(ProjectDto.fromModel),
+    })
+  }
+
+  async show({ auth, params, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+
+    return response.json({
+      data: ProjectDto.fromModel(project),
+    })
+  }
+
+  async store({ auth, request, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const payload = await request.validateUsing(createProjectValidator)
+    const project = await this.projectService.createProject(payload, user.id)
+
+    return response.status(201).json({
+      data: ProjectDto.fromModel(project),
+    })
+  }
+
+  async update({ auth, request, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params, ...payload } = await request.validateUsing(updateProjectValidator)
+    const project = await this.projectService.updateProject(params.projetId, user.id, payload)
+
+    return response.json({
+      data: ProjectDto.fromModel(project),
+    })
+  }
+
+  async destroy({ auth, request, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params } = await request.validateUsing(destroyProjectValidator)
+
+    await this.projectService.deleteProject(params.projectId, user.id)
+
+    return response.status(204)
+  }
+}

--- a/app/controllers/projects_controller.ts
+++ b/app/controllers/projects_controller.ts
@@ -5,6 +5,7 @@ import { ProjectService } from '#services/project_service'
 import {
   createProjectValidator,
   destroyProjectValidator,
+  showProjectValidator,
   updateProjectValidator,
 } from '#validators/project'
 import { ProjectDto } from '../dto/project_dto.js'
@@ -22,8 +23,9 @@ export default class ProjectsController {
     })
   }
 
-  async show({ auth, params, response }: HttpContext) {
+  async show({ auth, request, response }: HttpContext) {
     const user = auth.getUserOrFail()
+    const { params } = await request.validateUsing(showProjectValidator)
     const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
 
     return response.json({
@@ -44,7 +46,7 @@ export default class ProjectsController {
   async update({ auth, request, response }: HttpContext) {
     const user = auth.getUserOrFail()
     const { params, ...payload } = await request.validateUsing(updateProjectValidator)
-    const project = await this.projectService.updateProject(params.projetId, user.id, payload)
+    const project = await this.projectService.updateProject(params.projectId, user.id, payload)
 
     return response.json({
       data: ProjectDto.fromModel(project),

--- a/app/dto/project_dto.ts
+++ b/app/dto/project_dto.ts
@@ -10,8 +10,8 @@ export class ProjectDto {
       actionType: project.actionType,
       status: project.status,
       closedAt: project.closedAt?.toISO() ?? null,
-      createdAt: project.createdAt.toISO(),
-      updatedAt: project.updatedAt.toISO(),
+      createdAt: project.createdAt.toISO() as string,
+      updatedAt: project.updatedAt.toISO() as string,
     }
   }
 }

--- a/app/dto/project_dto.ts
+++ b/app/dto/project_dto.ts
@@ -1,0 +1,17 @@
+import Project from '#models/project'
+import type { ProjectJson } from '../../types/models.js'
+
+export class ProjectDto {
+  static fromModel(project: Project): ProjectJson {
+    return {
+      id: project.id,
+      name: project.name,
+      description: project.description,
+      actionType: project.actionType,
+      status: project.status,
+      closedAt: project.closedAt?.toISO() ?? null,
+      createdAt: project.createdAt.toISO(),
+      updatedAt: project.updatedAt.toISO(),
+    }
+  }
+}

--- a/app/models/captage.ts
+++ b/app/models/captage.ts
@@ -1,0 +1,42 @@
+import { DateTime } from 'luxon'
+import { BaseModel, beforeCreate, column, manyToMany } from '@adonisjs/lucid/orm'
+import type { ManyToMany } from '@adonisjs/lucid/types/relations'
+import { randomUUID } from 'node:crypto'
+import Project from '#models/project'
+
+export default class Captage extends BaseModel {
+  static table = 'captages'
+  static selfAssignPrimaryKey = true
+
+  @column({ isPrimary: true })
+  declare id: string
+
+  @beforeCreate()
+  static assignUuid(captage: Captage) {
+    captage.id = randomUUID()
+  }
+
+  @column()
+  declare code: string
+
+  @column()
+  declare name: string
+
+  @column()
+  declare bssCode: string
+
+  @column()
+  declare state: string
+
+  @manyToMany(() => Project, {
+    pivotTable: 'project_captage_relations',
+    pivotTimestamps: true,
+  })
+  declare projects: ManyToMany<typeof Project>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/app/models/exploitation.ts
+++ b/app/models/exploitation.ts
@@ -15,6 +15,7 @@ import Territoire from '#models/territoire'
 import LogEntry from '#models/log_entry'
 import Parcelle from '#models/parcelle'
 import User from '#models/user'
+import Project from '#models/project'
 
 export const ExploitationTagRelationTable = 'exploitation_tags_relations'
 
@@ -102,6 +103,12 @@ export default class Exploitation extends BaseModel {
 
   @hasMany(() => Parcelle)
   declare parcelles: HasMany<typeof Parcelle>
+
+  @manyToMany(() => Project, {
+    pivotTable: 'project_exploitation_relations',
+    pivotTimestamps: true,
+  })
+  declare projects: ManyToMany<typeof Project>
 
   @belongsTo(() => User)
   declare user: BelongsTo<typeof User>

--- a/app/models/parcelle.ts
+++ b/app/models/parcelle.ts
@@ -1,9 +1,10 @@
 import { DateTime } from 'luxon'
-import { BaseModel, beforeCreate, belongsTo, column } from '@adonisjs/lucid/orm'
+import { BaseModel, beforeCreate, belongsTo, column, manyToMany } from '@adonisjs/lucid/orm'
 import { randomUUID } from 'node:crypto'
 import Exploitation from '#models/exploitation'
-import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import type { BelongsTo, ManyToMany } from '@adonisjs/lucid/types/relations'
 import Culture from '#models/culture'
+import Project from '#models/project'
 
 export default class Parcelle extends BaseModel {
   static table = 'parcelles'
@@ -56,6 +57,12 @@ export default class Parcelle extends BaseModel {
 
   @belongsTo(() => Culture, { localKey: 'code', foreignKey: 'cultureCode' })
   declare culture: BelongsTo<typeof Culture>
+
+  @manyToMany(() => Project, {
+    pivotTable: 'project_parcelle_relations',
+    pivotTimestamps: true,
+  })
+  declare projects: ManyToMany<typeof Project>
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime

--- a/app/models/project.ts
+++ b/app/models/project.ts
@@ -1,0 +1,73 @@
+import { DateTime } from 'luxon'
+import { BaseModel, beforeCreate, belongsTo, column, manyToMany } from '@adonisjs/lucid/orm'
+import type { BelongsTo, ManyToMany } from '@adonisjs/lucid/types/relations'
+import { randomUUID } from 'node:crypto'
+import Exploitation from '#models/exploitation'
+import Parcelle from '#models/parcelle'
+import Captage from '#models/captage'
+import User from '#models/user'
+
+export const ProjectStatus = {
+  TO_BE_STARTED: 'to_be_started',
+  CURRENT: 'current',
+  COMPLETED: 'completed',
+  ABANDONED: 'abandoned',
+} as const
+
+export default class Project extends BaseModel {
+  static table = 'projects'
+  static selfAssignPrimaryKey = true
+
+  @column({ isPrimary: true })
+  declare id: string
+
+  @beforeCreate()
+  static assignUuid(project: Project) {
+    project.id = randomUUID()
+  }
+
+  @column()
+  declare name: string
+
+  @column()
+  declare description: string | null
+
+  @column()
+  declare actionType: string | null
+
+  @column()
+  declare userId: string
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
+
+  @column()
+  declare status: (typeof ProjectStatus)[keyof typeof ProjectStatus]
+
+  @manyToMany(() => Parcelle, {
+    pivotTable: 'project_parcelle_relations',
+    pivotTimestamps: true,
+  })
+  declare parcelles: ManyToMany<typeof Parcelle>
+
+  @manyToMany(() => Exploitation, {
+    pivotTable: 'project_exploitation_relations',
+    pivotTimestamps: true,
+  })
+  declare exploitations: ManyToMany<typeof Exploitation>
+
+  @manyToMany(() => Captage, {
+    pivotTable: 'project_captage_relations',
+    pivotTimestamps: true,
+  })
+  declare captages: ManyToMany<typeof Captage>
+
+  @column.dateTime()
+  declare closedAt: DateTime | null
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/app/services/aac_csv_service.ts
+++ b/app/services/aac_csv_service.ts
@@ -28,7 +28,7 @@ function wrapCsv(sections: string[]): string {
 
 @inject()
 export class AacCsvService {
-  constructor(private aacService: AacService) {}
+  constructor(protected aacService: AacService) {}
 
   private async getAacDto(aacCode: string): Promise<AacJson | null> {
     const raw = await this.aacService.getByCode(aacCode)

--- a/app/services/aac_service.ts
+++ b/app/services/aac_service.ts
@@ -692,7 +692,7 @@ export class AacService {
   /**
    * Returns all captages extracted from AAC installations.
    * The source parquet may contain the same installation across multiple AACs,
-   * so rows are deduplicated to satisfy unique constraints on `code` and `code_bss`.
+   * so rows are deduplicated to satisfy unique constraints on `code` and `bssCode`.
    */
   async getAllCaptagesFromInstallations(): Promise<CaptageSeedRow[]> {
     const conn = await getConnection()

--- a/app/services/aac_service.ts
+++ b/app/services/aac_service.ts
@@ -146,6 +146,24 @@ function normalizeValue(value: unknown): unknown {
   return value
 }
 
+type CaptageSeedRow = {
+  code: string
+  name: string
+  bssCode: string
+  state: string
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : null
+}
+
+function getCaptageStatePriority(state: string): number {
+  return state.toUpperCase() === 'ACTIF' ? 0 : 1
+}
+
 /**
  * Service for querying the AAC dataset stored as a Parquet file in S3 via DuckDB.
  * Provides methods to get paginated lists of AACs with optional search filters,
@@ -669,5 +687,68 @@ export class AacService {
 
     const result = await stmt.run()
     return (await result.getRowObjects()) as Array<{ code: string; name: string }>
+  }
+
+  /**
+   * Returns all captages extracted from AAC installations.
+   * The source parquet may contain the same installation across multiple AACs,
+   * so rows are deduplicated to satisfy unique constraints on `code` and `code_bss`.
+   */
+  async getAllCaptagesFromInstallations(): Promise<CaptageSeedRow[]> {
+    const conn = await getConnection()
+    const stmt = await conn.prepare(
+      'SELECT unnest(installations) AS installation FROM read_parquet($1) WHERE installations IS NOT NULL'
+    )
+    stmt.bindVarchar(1, getParquetPath())
+
+    const result = await stmt.run()
+    const rows = (await result.getRowObjects()) as Array<Record<string, unknown>>
+
+    const candidates = rows
+      .map((row) => normalizeValue(row.installation) as Record<string, unknown> | null)
+      .flatMap((installation): CaptageSeedRow[] => {
+        if (!installation || typeof installation !== 'object') return []
+
+        const code = normalizeString(installation.code)
+        const name = normalizeString(installation.nom)
+        const bssCode = normalizeString(installation.code_bss)
+        const state = normalizeString(installation.etat)
+
+        if (!code || !name || !bssCode || !state) return []
+
+        return [
+          {
+            code,
+            name,
+            bssCode,
+            state,
+          },
+        ]
+      })
+      .sort((left, right) => {
+        const byState = getCaptageStatePriority(left.state) - getCaptageStatePriority(right.state)
+        if (byState !== 0) return byState
+
+        const byCode = left.code.localeCompare(right.code)
+        if (byCode !== 0) return byCode
+
+        const byBssCode = left.bssCode.localeCompare(right.bssCode)
+        if (byBssCode !== 0) return byBssCode
+
+        return left.name.localeCompare(right.name)
+      })
+
+    const captagesByCode = new Map<string, CaptageSeedRow>()
+    const usedBssCodes = new Set<string>()
+
+    for (const captage of candidates) {
+      if (captagesByCode.has(captage.code)) continue
+      if (usedBssCodes.has(captage.bssCode)) continue
+
+      captagesByCode.set(captage.code, captage)
+      usedBssCodes.add(captage.bssCode)
+    }
+
+    return Array.from(captagesByCode.values())
   }
 }

--- a/app/services/project_service.ts
+++ b/app/services/project_service.ts
@@ -1,16 +1,8 @@
 import Project, { ProjectStatus } from '#models/project'
-import type { DateTime } from 'luxon'
-
-export type CreateProjectPayload = {
-  name: string
-  description?: string | null
-  actionType?: string | null
-  status?: Project['status']
-  closedAt?: DateTime | null
-}
+import { ModelAttributes } from '@adonisjs/lucid/types/model'
 
 export class ProjectService {
-  async createProject(payload: CreateProjectPayload, userId: string) {
+  async createProject(payload: Partial<ModelAttributes<Project>>, userId: string) {
     return Project.create({
       name: payload.name,
       description: payload.description ?? null,
@@ -30,7 +22,11 @@ export class ProjectService {
     await project.delete()
   }
 
-  async updateProject(projectId: string, userId: string, payload: Partial<CreateProjectPayload>) {
+  async updateProject(
+    projectId: string,
+    userId: string,
+    payload: Partial<ModelAttributes<Project>>
+  ) {
     const project = await this.findOwnedProjectOrFail(projectId, userId)
 
     project.merge(payload)

--- a/app/services/project_service.ts
+++ b/app/services/project_service.ts
@@ -1,0 +1,41 @@
+import Project, { ProjectStatus } from '#models/project'
+import type { DateTime } from 'luxon'
+
+export type CreateProjectPayload = {
+  name: string
+  description?: string | null
+  actionType?: string | null
+  status?: Project['status']
+  closedAt?: DateTime | null
+}
+
+export class ProjectService {
+  async createProject(payload: CreateProjectPayload, userId: string) {
+    return Project.create({
+      name: payload.name,
+      description: payload.description ?? null,
+      actionType: payload.actionType ?? null,
+      status: payload.status ?? ProjectStatus.TO_BE_STARTED,
+      userId,
+    })
+  }
+
+  async findOwnedProjectOrFail(projectId: string, userId: string) {
+    return Project.query().where('id', projectId).andWhere('userId', userId).firstOrFail()
+  }
+
+  async deleteProject(projectId: string, userId: string) {
+    const project = await this.findOwnedProjectOrFail(projectId, userId)
+
+    await project.delete()
+  }
+
+  async updateProject(projectId: string, userId: string, payload: Partial<CreateProjectPayload>) {
+    const project = await this.findOwnedProjectOrFail(projectId, userId)
+
+    project.merge(payload)
+    await project.save()
+
+    return project
+  }
+}

--- a/app/validators/project.ts
+++ b/app/validators/project.ts
@@ -11,6 +11,13 @@ export const createProjectValidator = vine.compile(
   })
 )
 
+export const showProjectValidator = vine.compile(
+  vine.object({
+    params: vine.object({
+      projectId: vine.string().uuid(),
+    }),
+  })
+)
 export const destroyProjectValidator = vine.compile(
   vine.object({
     params: vine.object({
@@ -31,7 +38,7 @@ export const updateProjectValidator = vine.compile(
       .nullable()
       .transform((value) => (value ? DateTime.fromJSDate(value) : value)),
     params: vine.object({
-      projetId: vine.string().uuid(),
+      projectId: vine.string().uuid(),
     }),
   })
 )

--- a/app/validators/project.ts
+++ b/app/validators/project.ts
@@ -1,0 +1,37 @@
+import vine from '@vinejs/vine'
+import { DateTime } from 'luxon'
+import { ProjectStatus } from '#models/project'
+
+export const createProjectValidator = vine.compile(
+  vine.object({
+    name: vine.string().maxLength(255),
+    description: vine.string().maxLength(4000).optional().nullable(),
+    actionType: vine.string().maxLength(255).optional().nullable(),
+    status: vine.enum(Object.values(ProjectStatus)).optional(),
+  })
+)
+
+export const destroyProjectValidator = vine.compile(
+  vine.object({
+    params: vine.object({
+      projectId: vine.string().uuid(),
+    }),
+  })
+)
+
+export const updateProjectValidator = vine.compile(
+  vine.object({
+    name: vine.string().maxLength(255).optional(),
+    description: vine.string().maxLength(4000).optional().nullable(),
+    actionType: vine.string().maxLength(255).optional().nullable(),
+    status: vine.enum(Object.values(ProjectStatus)).optional(),
+    closedAt: vine
+      .date()
+      .optional()
+      .nullable()
+      .transform((value) => (value ? DateTime.fromJSDate(value) : value)),
+    params: vine.object({
+      projetId: vine.string().uuid(),
+    }),
+  })
+)

--- a/database/factories/captage_factory.ts
+++ b/database/factories/captage_factory.ts
@@ -1,0 +1,14 @@
+import factory from '@adonisjs/lucid/factories'
+import { fakerFR as faker } from '@faker-js/faker'
+import Captage from '#models/captage'
+
+export const CaptageFactory = factory
+  .define(Captage, async () => {
+    return {
+      code: faker.string.alphanumeric({ length: 8, casing: 'upper' }),
+      name: faker.location.city(),
+      bssCode: faker.string.alphanumeric({ length: 12, casing: 'upper' }),
+      state: faker.helpers.arrayElement(['active', 'inactive', 'abandoned']),
+    }
+  })
+  .build()

--- a/database/factories/project_factory.ts
+++ b/database/factories/project_factory.ts
@@ -1,0 +1,25 @@
+import factory from '@adonisjs/lucid/factories'
+import { fakerFR as faker } from '@faker-js/faker'
+import Project, { ProjectStatus } from '#models/project'
+import { UserFactory } from '#database/factories/user_factory'
+
+const ProjectActionType = {
+  STUDY: 'study',
+  DIAGNOSIS: 'diagnosis',
+  COORDINATION: 'coordination',
+  WORKS: 'works',
+  MONITORING: 'monitoring',
+} as const
+
+export const ProjectFactory = factory
+  .define(Project, async () => {
+    return {
+      name: faker.company.catchPhrase(),
+      description: faker.lorem.sentence(),
+      actionType: faker.helpers.arrayElement(Object.values(ProjectActionType)),
+      status: ProjectStatus.TO_BE_STARTED,
+      closedAt: null,
+    }
+  })
+  .relation('user', () => UserFactory)
+  .build()

--- a/database/migrations/1775000000000_create_captages_table.ts
+++ b/database/migrations/1775000000000_create_captages_table.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'captages'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.uuid('id').primary().notNullable()
+      table.string('code').notNullable().unique()
+      table.string('name').notNullable()
+      table.string('bss_code').notNullable().unique()
+      table.string('state').notNullable()
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/migrations/1775000000001_create_projects_table.ts
+++ b/database/migrations/1775000000001_create_projects_table.ts
@@ -1,0 +1,35 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+import User from '#models/user'
+
+const ProjectStatus = {
+  TO_BE_STARTED: 'to_be_started',
+  CURRENT: 'current',
+  COMPLETED: 'completed',
+  ABANDONED: 'abandoned',
+} as const
+
+export default class extends BaseSchema {
+  protected tableName = 'projects'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.uuid('id').primary().notNullable()
+      table.string('name').notNullable()
+      table.text('description').nullable()
+      table.text('action_type').nullable()
+      table.uuid('user_id').notNullable().references('id').inTable(User.table).onDelete('CASCADE')
+      table
+        .enum('status', Object.values(ProjectStatus))
+        .defaultTo(ProjectStatus.TO_BE_STARTED)
+        .notNullable()
+      table.timestamp('closed_at').nullable()
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/migrations/1775000000002_create_project_parcelle_relations_table.ts
+++ b/database/migrations/1775000000002_create_project_parcelle_relations_table.ts
@@ -1,0 +1,33 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'project_parcelle_relations'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+
+      table
+        .uuid('project_id')
+        .notNullable()
+        .references('id')
+        .inTable('projects')
+        .onDelete('CASCADE')
+      table
+        .uuid('parcelle_id')
+        .notNullable()
+        .references('id')
+        .inTable('parcelles')
+        .onDelete('CASCADE')
+
+      table.unique(['project_id', 'parcelle_id'])
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/migrations/1775000000003_create_project_exploitation_relations_table.ts
+++ b/database/migrations/1775000000003_create_project_exploitation_relations_table.ts
@@ -1,0 +1,33 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'project_exploitation_relations'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+
+      table
+        .uuid('project_id')
+        .notNullable()
+        .references('id')
+        .inTable('projects')
+        .onDelete('CASCADE')
+      table
+        .uuid('exploitation_id')
+        .notNullable()
+        .references('id')
+        .inTable('exploitations')
+        .onDelete('CASCADE')
+
+      table.unique(['project_id', 'exploitation_id'])
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/migrations/1775000000004_create_project_captage_relations_table.ts
+++ b/database/migrations/1775000000004_create_project_captage_relations_table.ts
@@ -1,0 +1,33 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'project_captage_relations'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+
+      table
+        .uuid('project_id')
+        .notNullable()
+        .references('id')
+        .inTable('projects')
+        .onDelete('CASCADE')
+      table
+        .uuid('captage_id')
+        .notNullable()
+        .references('id')
+        .inTable('captages')
+        .onDelete('CASCADE')
+
+      table.unique(['project_id', 'captage_id'])
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/seeders/9_captage_seeder.ts
+++ b/database/seeders/9_captage_seeder.ts
@@ -1,0 +1,12 @@
+import { BaseSeeder } from '@adonisjs/lucid/seeders'
+import { AacService } from '#services/aac_service'
+import Captage from '#models/captage'
+
+export default class CaptageSeeder extends BaseSeeder {
+  public async run() {
+    const aacService = new AacService()
+    const rows = await aacService.getAllCaptagesFromInstallations()
+
+    await Captage.updateOrCreateMany('code', rows)
+  }
+}

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -222,7 +222,7 @@ router
         router.get('projets', [ProjectsController, 'index']).as('projets.index')
         router.get('projets/:projectId', [ProjectsController, 'show']).as('projets.show')
         router.post('projets', [ProjectsController, 'store']).as('projets.store')
-        router.patch('projets/:projetId', [ProjectsController, 'update']).as('projets.update')
+        router.patch('projets/:projectId', [ProjectsController, 'update']).as('projets.update')
         router.delete('projets/:projectId', [ProjectsController, 'destroy']).as('projets.destroy')
       })
       .use(middleware.territoireAssignation())

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -16,6 +16,7 @@ const SessionController = () => import('#controllers/session_controller')
 const LogEntriesController = () => import('#controllers/log_entries_controller')
 const VisualisationController = () => import('#controllers/visualisation_controller')
 const AacController = () => import('#controllers/aac_controller')
+const ProjectsController = () => import('#controllers/projects_controller')
 
 router.get('/', ({ response }) => response.redirect('login'))
 
@@ -217,6 +218,12 @@ router
           .get('aac/:code/installations/:installationCode/analyses', [AacController, 'analyses'])
           .where('code', /^\d+$/)
           .as('aac.analyses')
+
+        router.get('projets', [ProjectsController, 'index']).as('projets.index')
+        router.get('projets/:projectId', [ProjectsController, 'show']).as('projets.show')
+        router.post('projets', [ProjectsController, 'store']).as('projets.store')
+        router.patch('projets/:projetId', [ProjectsController, 'update']).as('projets.update')
+        router.delete('projets/:projectId', [ProjectsController, 'destroy']).as('projets.destroy')
       })
       .use(middleware.territoireAssignation())
   })

--- a/tests/functional/project/projects_destroy.spec.ts
+++ b/tests/functional/project/projects_destroy.spec.ts
@@ -1,0 +1,53 @@
+import testUtils from '@adonisjs/core/services/test_utils'
+import { test } from '@japa/runner'
+import Project from '#models/project'
+import { UserFactory } from '#database/factories/user_factory'
+import { ProjectFactory } from '#database/factories/project_factory'
+
+test.group('Projects - Destroy Route', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('I can delete one of my projects', async ({ assert, client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const response = await client
+      .delete(route('projets.destroy', { projectId: project.id }))
+      .loginAs(user)
+      .withCsrfToken()
+
+    response.assertStatus(204)
+
+    const deletedProject = await Project.find(project.id)
+    assert.isNull(deletedProject)
+  })
+
+  test("I can't delete another user's project", async ({ assert, client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+
+    const response = await client
+      .delete(route('projets.destroy', { projectId: project.id }))
+      .header('Accept', 'application/json')
+      .loginAs(user)
+      .withCsrfToken()
+
+    response.assertStatus(404)
+
+    const remainingProject = await Project.find(project.id)
+    assert.isNotNull(remainingProject)
+  })
+
+  test("I can't delete a project with an invalid id", async ({ client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+
+    const response = await client
+      .delete(route('projets.destroy', { projectId: 'invalid-project-id' }))
+      .header('Accept', 'application/json')
+      .loginAs(user)
+      .withCsrfToken()
+
+    response.assertStatus(422)
+  })
+})

--- a/tests/functional/project/projects_index.spec.ts
+++ b/tests/functional/project/projects_index.spec.ts
@@ -1,0 +1,53 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { UserFactory } from '#database/factories/user_factory'
+import { TerritoireFactory } from '#database/factories/territoire_factory'
+import { ProjectFactory } from '#database/factories/project_factory'
+
+test.group('Projects - Index Route', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('I can list projects', async ({ assert, client, route }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const projects = await ProjectFactory.with('user').createMany(2)
+    const otherUserProject = await ProjectFactory.with('user').create()
+
+    for (const project of projects) {
+      await project.related('user').associate(user)
+    }
+
+    const response = await client.get(route('projets.index')).loginAs(user)
+
+    response.assertStatus(200)
+
+    const body = response.body() as {
+      data: Array<{
+        id: string
+        name: string
+        description: string | null
+        actionType: string | null
+        status: string
+        closedAt: string | null
+        createdAt: string | null
+        updatedAt: string | null
+      }>
+    }
+
+    assert.equal(body.data.length, 2)
+    assert.notInclude(
+      body.data.map((project) => project.id),
+      otherUserProject.id
+    )
+    assert.deepEqual(
+      body.data.map((project) => project.id).sort(),
+      projects.map((project) => project.id).sort()
+    )
+    assert.sameMembers(
+      body.data.map((project) => project.status),
+      projects.map((project) => project.status)
+    )
+  })
+})

--- a/tests/functional/project/projects_show.spec.ts
+++ b/tests/functional/project/projects_show.spec.ts
@@ -1,0 +1,42 @@
+import testUtils from '@adonisjs/core/services/test_utils'
+import { test } from '@japa/runner'
+import { UserFactory } from '#database/factories/user_factory'
+import { ProjectFactory } from '#database/factories/project_factory'
+
+test.group('Projects - Show Route', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('I can fetch one of my projects', async ({ assert, client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const response = await client
+      .get(route('projets.show', { projectId: project.id }))
+      .loginAs(user)
+
+    response.assertStatus(200)
+
+    const body = response.body() as {
+      data: {
+        id: string
+        name: string
+      }
+    }
+
+    assert.equal(body.data.id, project.id)
+    assert.equal(body.data.name, project.name)
+  })
+
+  test("I can't fetch another user's project", async ({ client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+
+    const response = await client
+      .get(route('projets.show', { projectId: project.id }))
+      .header('Accept', 'application/json')
+      .loginAs(user)
+
+    response.assertStatus(404)
+  })
+})

--- a/tests/functional/project/projects_store.spec.ts
+++ b/tests/functional/project/projects_store.spec.ts
@@ -1,0 +1,88 @@
+import testUtils from '@adonisjs/core/services/test_utils'
+import { test } from '@japa/runner'
+import Project, { ProjectStatus } from '#models/project'
+import { UserFactory } from '#database/factories/user_factory'
+
+test.group('Projects - Store Route', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('I can create a project for the authenticated user', async ({ assert, client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+
+    const response = await client
+      .post(route('projets.store'))
+      .loginAs(user)
+      .json({
+        name: 'Protect groundwater catchments',
+        description: 'Initial scoping and planning',
+        actionType: 'study',
+      })
+      .withCsrfToken()
+
+    response.assertStatus(201)
+
+    const savedProject = await Project.findByOrFail('name', 'Protect groundwater catchments')
+
+    assert.equal(savedProject.userId, user.id)
+    assert.equal(savedProject.status, ProjectStatus.TO_BE_STARTED)
+    assert.equal(savedProject.description, 'Initial scoping and planning')
+    assert.equal(savedProject.actionType, 'study')
+
+    const body = response.body() as {
+      data: {
+        id: string
+        name: string
+        description: string | null
+        actionType: string | null
+        status: string
+        closedAt: string | null
+      }
+    }
+
+    assert.equal(body.data.id, savedProject.id)
+    assert.equal(body.data.name, savedProject.name)
+    assert.equal(body.data.status, ProjectStatus.TO_BE_STARTED)
+    assert.isNull(body.data.closedAt)
+  })
+
+  test('The authenticated user is always used as the project owner', async ({
+    assert,
+    client,
+    route,
+  }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const otherUser = await UserFactory.create()
+
+    const response = await client
+      .post(route('projets.store'))
+      .loginAs(user)
+      .json({
+        name: 'Ownership is derived from auth',
+        userId: otherUser.id,
+        status: ProjectStatus.CURRENT,
+      })
+      .withCsrfToken()
+
+    response.assertStatus(201)
+
+    const savedProject = await Project.findByOrFail('name', 'Ownership is derived from auth')
+
+    assert.equal(savedProject.userId, user.id)
+    assert.equal(savedProject.status, ProjectStatus.CURRENT)
+  })
+
+  test("I can't create a project without a name", async ({ client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+
+    const response = await client
+      .post(route('projets.store'))
+      .header('Accept', 'application/json')
+      .loginAs(user)
+      .json({
+        description: 'Missing required name',
+      })
+      .withCsrfToken()
+
+    response.assertStatus(422)
+  })
+})

--- a/tests/functional/project/projects_update.spec.ts
+++ b/tests/functional/project/projects_update.spec.ts
@@ -13,7 +13,7 @@ test.group('Projects - Update Route', (group) => {
     await project.related('user').associate(user)
 
     const response = await client
-      .patch(route('projets.update', { projetId: project.id }))
+      .patch(route('projets.update', { projectId: project.id }))
       .loginAs(user)
       .json({
         name: 'Updated project name',
@@ -49,7 +49,7 @@ test.group('Projects - Update Route', (group) => {
     await project.related('user').associate(user)
 
     const response = await client
-      .patch(route('projets.update', { projetId: project.id }))
+      .patch(route('projets.update', { projectId: project.id }))
       .loginAs(user)
       .json({
         description: null,
@@ -70,7 +70,7 @@ test.group('Projects - Update Route', (group) => {
     const project = await ProjectFactory.with('user').create()
 
     const response = await client
-      .patch(route('projets.update', { projetId: project.id }))
+      .patch(route('projets.update', { projectId: project.id }))
       .header('Accept', 'application/json')
       .loginAs(user)
       .json({
@@ -88,7 +88,7 @@ test.group('Projects - Update Route', (group) => {
     const user = await UserFactory.with('territoires', 1).create()
 
     const response = await client
-      .patch(route('projets.update', { projetId: 'invalid-project-id' }))
+      .patch(route('projets.update', { projectId: 'invalid-project-id' }))
       .header('Accept', 'application/json')
       .loginAs(user)
       .json({

--- a/tests/functional/project/projects_update.spec.ts
+++ b/tests/functional/project/projects_update.spec.ts
@@ -1,0 +1,101 @@
+import testUtils from '@adonisjs/core/services/test_utils'
+import { test } from '@japa/runner'
+import Project, { ProjectStatus } from '#models/project'
+import { UserFactory } from '#database/factories/user_factory'
+import { ProjectFactory } from '#database/factories/project_factory'
+
+test.group('Projects - Update Route', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('I can partially update one of my projects', async ({ assert, client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const response = await client
+      .patch(route('projets.update', { projetId: project.id }))
+      .loginAs(user)
+      .json({
+        name: 'Updated project name',
+        status: ProjectStatus.CURRENT,
+      })
+      .withCsrfToken()
+
+    response.assertStatus(200)
+
+    const updatedProject = await Project.findByOrFail('id', project.id)
+
+    assert.equal(updatedProject.name, 'Updated project name')
+    assert.equal(updatedProject.status, ProjectStatus.CURRENT)
+    assert.equal(updatedProject.description, project.description)
+    assert.equal(updatedProject.actionType, project.actionType)
+
+    const body = response.body() as {
+      data: {
+        id: string
+        name: string
+        status: string
+      }
+    }
+
+    assert.equal(body.data.id, project.id)
+    assert.equal(body.data.name, 'Updated project name')
+    assert.equal(body.data.status, ProjectStatus.CURRENT)
+  })
+
+  test('I can nullify nullable fields on one of my projects', async ({ assert, client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const response = await client
+      .patch(route('projets.update', { projetId: project.id }))
+      .loginAs(user)
+      .json({
+        description: null,
+        actionType: null,
+      })
+      .withCsrfToken()
+
+    response.assertStatus(200)
+
+    const updatedProject = await Project.findByOrFail('id', project.id)
+
+    assert.isNull(updatedProject.description)
+    assert.isNull(updatedProject.actionType)
+  })
+
+  test("I can't update another user's project", async ({ assert, client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+
+    const response = await client
+      .patch(route('projets.update', { projetId: project.id }))
+      .header('Accept', 'application/json')
+      .loginAs(user)
+      .json({
+        name: 'Should not update',
+      })
+      .withCsrfToken()
+
+    response.assertStatus(404)
+
+    const unchangedProject = await Project.findByOrFail('id', project.id)
+    assert.notEqual(unchangedProject.name, 'Should not update')
+  })
+
+  test("I can't update a project with an invalid id", async ({ client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+
+    const response = await client
+      .patch(route('projets.update', { projetId: 'invalid-project-id' }))
+      .header('Accept', 'application/json')
+      .loginAs(user)
+      .json({
+        name: 'Will fail validation',
+      })
+      .withCsrfToken()
+
+    response.assertStatus(422)
+  })
+})

--- a/tests/unit/project/project_model.spec.ts
+++ b/tests/unit/project/project_model.spec.ts
@@ -1,0 +1,40 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { ProjectFactory } from '#database/factories/project_factory'
+import { ExploitationFactory } from '#database/factories/exploitation_factory'
+import { ParcelleFactory } from '#database/factories/parcelle_factory'
+import { CaptageFactory } from '#database/factories/captage_factory'
+
+test.group('Project model', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('I can attach parcelles, exploitations and captages to a project', async ({ assert }) => {
+    const project = await ProjectFactory.with('user').create()
+    const parcelles = await ParcelleFactory.createMany(2)
+    const exploitations = await ExploitationFactory.createMany(2)
+    const captages = await CaptageFactory.createMany(2)
+
+    await project.related('parcelles').attach(parcelles.map((parcelle) => parcelle.id))
+    await project
+      .related('exploitations')
+      .attach(exploitations.map((exploitation) => exploitation.id))
+    await project.related('captages').attach(captages.map((captage) => captage.id))
+
+    await project.load('parcelles')
+    await project.load('exploitations')
+    await project.load('captages')
+
+    assert.deepEqual(
+      project.parcelles.map((parcelle) => parcelle.id).sort(),
+      parcelles.map((parcelle) => parcelle.id).sort()
+    )
+    assert.deepEqual(
+      project.exploitations.map((exploitation) => exploitation.id).sort(),
+      exploitations.map((exploitation) => exploitation.id).sort()
+    )
+    assert.deepEqual(
+      project.captages.map((captage) => captage.id).sort(),
+      captages.map((captage) => captage.id).sort()
+    )
+  })
+})

--- a/types/models.ts
+++ b/types/models.ts
@@ -77,8 +77,8 @@ export type ProjectJson = {
   actionType: string | null
   status: 'to_be_started' | 'current' | 'completed' | 'abandoned'
   closedAt: string | null
-  createdAt: string | null
-  updatedAt: string | null
+  createdAt: string
+  updatedAt: string
 }
 
 export type ExploitationJson = {

--- a/types/models.ts
+++ b/types/models.ts
@@ -70,6 +70,17 @@ export type ParcelleJson = {
   comment: string | null
 }
 
+export type ProjectJson = {
+  id: string
+  name: string
+  description: string | null
+  actionType: string | null
+  status: 'to_be_started' | 'current' | 'completed' | 'abandoned'
+  closedAt: string | null
+  createdAt: string | null
+  updatedAt: string | null
+}
+
 export type ExploitationJson = {
   id: string
   name: string


### PR DESCRIPTION
Cette PR ajoute les routes de back-end pour créer, modifier, supprimer des projets, ainsi que les modèles et migrations pour créer les projets et les captages rattachés.

Elle n'ajoute aucune fonctionnalité visible par l'utilisateur, mais est nécessaire pour le développement du front-end.
