### PR TITLE
Trie les substances affichées dans la liste déroulante

### DIFF
--- a/app/services/aac_service.ts
+++ b/app/services/aac_service.ts
@@ -497,7 +497,8 @@ export class AacService {
         CAST(code_parametre AS INTEGER) AS code_parametre,
         ANY_VALUE(libelle_parametre) AS libelle_parametre,
         ANY_VALUE(code_unite) AS code_unite,
-        BOOL_OR(${SQL_DEP_ANY}) AS has_dep
+        BOOL_OR(${SQL_DEP_ANY}) AS has_dep,
+        MAX(resultat_traduction) AS max_value
       FROM read_parquet($1)
       WHERE code_installation = $2
         AND date_part('year', date_prelevement) BETWEEN $3 AND $4
@@ -515,9 +516,10 @@ export class AacService {
     const rows = (await result.getRowObjects()) as Array<Record<string, unknown>>
     return rows.map((r) => ({
       code_parametre: Number(r.code_parametre),
-      libelle_parametre: String(r.libelle_parametre),
+      libelle_parametre: r.libelle_parametre != null ? String(r.libelle_parametre) : '',
       code_unite: String(r.code_unite ?? ''),
       has_dep: Boolean(r.has_dep),
+      max_value: Number(r.max_value ?? 0),
     }))
   }
 

--- a/inertia/components/captage/chroniques-par-substances.tsx
+++ b/inertia/components/captage/chroniques-par-substances.tsx
@@ -13,6 +13,22 @@ type Props = {
   yearMax: number
 }
 
+function groupSubstances(list: SubstanceItem[]): {
+  withDep: SubstanceItem[]
+  withoutDep: SubstanceItem[]
+  notDetected: SubstanceItem[]
+} {
+  const filtered = list.filter((s) => s.libelle_parametre && s.libelle_parametre.trim() !== '')
+  const byName = (a: SubstanceItem, b: SubstanceItem) =>
+    a.libelle_parametre.localeCompare(b.libelle_parametre)
+
+  return {
+    withDep: filtered.filter((s) => s.has_dep).sort(byName),
+    withoutDep: filtered.filter((s) => !s.has_dep && s.max_value > 0).sort(byName),
+    notDetected: filtered.filter((s) => !s.has_dep && s.max_value === 0).sort(byName),
+  }
+}
+
 export default function ChroniquesParSubstances({
   aacCode,
   installationCode,
@@ -32,7 +48,9 @@ export default function ChroniquesParSubstances({
     `${baseUrl}/substances${yearParams}`,
     'Impossible de charger les substances.',
     (data) => {
-      setSelectedCode(data.length > 0 ? data[0].code_parametre : null)
+      const { withDep, withoutDep, notDetected } = groupSubstances(data)
+      const first = withDep[0] ?? withoutDep[0] ?? notDetected[0]
+      setSelectedCode(first ? first.code_parametre : null)
     }
   )
 
@@ -74,12 +92,28 @@ export default function ChroniquesParSubstances({
             }}
             style={{ marginBottom: 0, maxWidth: 400 }}
           >
-            {(substances ?? []).map((s) => (
-              <option key={s.code_parametre} value={s.code_parametre}>
-                {s.libelle_parametre}
-                {s.has_dep ? ' ⚠' : ''}
-              </option>
-            ))}
+            {(() => {
+              const { withDep, withoutDep, notDetected } = groupSubstances(substances ?? [])
+              const renderOption = (s: SubstanceItem) => (
+                <option key={s.code_parametre} value={s.code_parametre}>
+                  {s.libelle_parametre}
+                  {s.has_dep ? ' ⚠' : ''}
+                </option>
+              )
+              return (
+                <>
+                  {withDep.length > 0 && (
+                    <optgroup label="En dépassement">{withDep.map(renderOption)}</optgroup>
+                  )}
+                  {withoutDep.length > 0 && (
+                    <optgroup label="Sans dépassement">{withoutDep.map(renderOption)}</optgroup>
+                  )}
+                  {notDetected.length > 0 && (
+                    <optgroup label="Non détectée">{notDetected.map(renderOption)}</optgroup>
+                  )}
+                </>
+              )
+            })()}
           </Select>
         )}
       </div>

--- a/inertia/components/captage/chroniques-par-substances.tsx
+++ b/inertia/components/captage/chroniques-par-substances.tsx
@@ -29,6 +29,30 @@ function groupSubstances(list: SubstanceItem[]): {
   }
 }
 
+function SubstanceOptions({ substances }: { substances: SubstanceItem[] }) {
+  const { withDep, withoutDep, notDetected } = groupSubstances(substances)
+  const renderOption = (s: SubstanceItem) => (
+    <option key={s.code_parametre} value={s.code_parametre}>
+      {s.libelle_parametre}
+      {s.has_dep ? ' ⚠' : ''}
+    </option>
+  )
+
+  return (
+    <>
+      {withDep.length > 0 && (
+        <optgroup label="En dépassement">{withDep.map(renderOption)}</optgroup>
+      )}
+      {withoutDep.length > 0 && (
+        <optgroup label="Sans dépassement">{withoutDep.map(renderOption)}</optgroup>
+      )}
+      {notDetected.length > 0 && (
+        <optgroup label="Non détectée">{notDetected.map(renderOption)}</optgroup>
+      )}
+    </>
+  )
+}
+
 export default function ChroniquesParSubstances({
   aacCode,
   installationCode,
@@ -92,28 +116,7 @@ export default function ChroniquesParSubstances({
             }}
             style={{ marginBottom: 0, maxWidth: 400 }}
           >
-            {(() => {
-              const { withDep, withoutDep, notDetected } = groupSubstances(substances ?? [])
-              const renderOption = (s: SubstanceItem) => (
-                <option key={s.code_parametre} value={s.code_parametre}>
-                  {s.libelle_parametre}
-                  {s.has_dep ? ' ⚠' : ''}
-                </option>
-              )
-              return (
-                <>
-                  {withDep.length > 0 && (
-                    <optgroup label="En dépassement">{withDep.map(renderOption)}</optgroup>
-                  )}
-                  {withoutDep.length > 0 && (
-                    <optgroup label="Sans dépassement">{withoutDep.map(renderOption)}</optgroup>
-                  )}
-                  {notDetected.length > 0 && (
-                    <optgroup label="Non détectée">{notDetected.map(renderOption)}</optgroup>
-                  )}
-                </>
-              )
-            })()}
+            <SubstanceOptions substances={substances ?? []} />
           </Select>
         )}
       </div>

--- a/inertia/components/captage/chroniques-par-substances.tsx
+++ b/inertia/components/captage/chroniques-par-substances.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { fr } from '@codegouvfr/react-dsfr'
-import Select from '@codegouvfr/react-dsfr/Select'
+import SingleSelectMenu, { OptionType } from '~/ui/SingleSelectMenu'
 import Loader from '~/ui/Loader'
 import type { SubstanceItem, ChroniqueData } from '#types/captage'
 import { useFetch } from '~/hooks/use-fetch'
@@ -29,28 +29,26 @@ function groupSubstances(list: SubstanceItem[]): {
   }
 }
 
-function SubstanceOptions({ substances }: { substances: SubstanceItem[] }) {
+function toSelectOptions(
+  substances: SubstanceItem[],
+  selectedCode: number | null
+): OptionType<number>[] {
   const { withDep, withoutDep, notDetected } = groupSubstances(substances)
-  const renderOption = (s: SubstanceItem) => (
-    <option key={s.code_parametre} value={s.code_parametre}>
-      {s.libelle_parametre}
-      {s.has_dep ? ' ⚠' : ''}
-    </option>
-  )
+  const toOption =
+    (group: string) =>
+    (s: SubstanceItem): OptionType<number> => ({
+      value: s.code_parametre,
+      label: s.libelle_parametre,
+      isSelected: s.code_parametre === selectedCode,
+      group,
+      iconId: s.has_dep ? 'fr-icon-warning-fill' : undefined,
+    })
 
-  return (
-    <>
-      {withDep.length > 0 && (
-        <optgroup label="En dépassement">{withDep.map(renderOption)}</optgroup>
-      )}
-      {withoutDep.length > 0 && (
-        <optgroup label="Sans dépassement">{withoutDep.map(renderOption)}</optgroup>
-      )}
-      {notDetected.length > 0 && (
-        <optgroup label="Non détectée">{notDetected.map(renderOption)}</optgroup>
-      )}
-    </>
-  )
+  return [
+    ...withDep.map(toOption('En dépassement')),
+    ...withoutDep.map(toOption('Sans dépassement')),
+    ...notDetected.map(toOption('Non détectée')),
+  ]
 }
 
 export default function ChroniquesParSubstances({
@@ -107,17 +105,13 @@ export default function ChroniquesParSubstances({
         {loadingSubstances ? (
           <Loader type="dots" size="sm" />
         ) : (
-          <Select
-            label="Sélectionnez une substance"
-            nativeSelectProps={{
-              id: 'substance-select',
-              value: selectedCode ?? '',
-              onChange: (e) => setSelectedCode(Number(e.target.value)),
-            }}
-            style={{ marginBottom: 0, maxWidth: 400 }}
-          >
-            <SubstanceOptions substances={substances ?? []} />
-          </Select>
+          <div style={{ maxWidth: 400 }}>
+            <SingleSelectMenu
+              label="Sélectionnez une substance"
+              options={toSelectOptions(substances ?? [], selectedCode)}
+              onChange={(opt) => setSelectedCode(opt.value)}
+            />
+          </div>
         )}
       </div>
 

--- a/inertia/components/captage/chroniques-par-substances.tsx
+++ b/inertia/components/captage/chroniques-par-substances.tsx
@@ -13,44 +13,6 @@ type Props = {
   yearMax: number
 }
 
-function groupSubstances(list: SubstanceItem[]): {
-  withDep: SubstanceItem[]
-  withoutDep: SubstanceItem[]
-  notDetected: SubstanceItem[]
-} {
-  const filtered = list.filter((s) => s.libelle_parametre && s.libelle_parametre.trim() !== '')
-  const byName = (a: SubstanceItem, b: SubstanceItem) =>
-    a.libelle_parametre.localeCompare(b.libelle_parametre)
-
-  return {
-    withDep: filtered.filter((s) => s.has_dep).sort(byName),
-    withoutDep: filtered.filter((s) => !s.has_dep && s.max_value > 0).sort(byName),
-    notDetected: filtered.filter((s) => !s.has_dep && s.max_value === 0).sort(byName),
-  }
-}
-
-function toSelectOptions(
-  substances: SubstanceItem[],
-  selectedCode: number | null
-): OptionType<number>[] {
-  const { withDep, withoutDep, notDetected } = groupSubstances(substances)
-  const toOption =
-    (group: string) =>
-    (s: SubstanceItem): OptionType<number> => ({
-      value: s.code_parametre,
-      label: s.libelle_parametre,
-      isSelected: s.code_parametre === selectedCode,
-      group,
-      iconId: s.has_dep ? 'fr-icon-warning-fill' : undefined,
-    })
-
-  return [
-    ...withDep.map(toOption('En dépassement')),
-    ...withoutDep.map(toOption('Sans dépassement')),
-    ...notDetected.map(toOption('Non détectée')),
-  ]
-}
-
 export default function ChroniquesParSubstances({
   aacCode,
   installationCode,
@@ -70,11 +32,30 @@ export default function ChroniquesParSubstances({
     `${baseUrl}/substances${yearParams}`,
     'Impossible de charger les substances.',
     (data) => {
-      const { withDep, withoutDep, notDetected } = groupSubstances(data)
-      const first = withDep[0] ?? withoutDep[0] ?? notDetected[0]
-      setSelectedCode(first ? first.code_parametre : null)
+      const filtered = data.filter((s) => s.libelle_parametre?.trim())
+      const first =
+        filtered.find((s) => s.has_dep) ??
+        filtered.find((s) => !s.has_dep && s.max_value > 0) ??
+        filtered.find((s) => s.max_value === 0)
+      setSelectedCode(first?.code_parametre ?? null)
     }
   )
+
+  const sorted = (substances ?? [])
+    .filter((s) => s.libelle_parametre?.trim())
+    .sort((a, b) => a.libelle_parametre.localeCompare(b.libelle_parametre))
+
+  const substanceOptions: OptionType<number>[] = [
+    ...sorted.filter((s) => s.has_dep),
+    ...sorted.filter((s) => !s.has_dep && s.max_value > 0),
+    ...sorted.filter((s) => !s.has_dep && s.max_value === 0),
+  ].map((s) => ({
+    value: s.code_parametre,
+    label: s.libelle_parametre,
+    isSelected: s.code_parametre === selectedCode,
+    group: s.has_dep ? 'En dépassement' : s.max_value > 0 ? 'Sans dépassement' : 'Non détectée',
+    iconId: s.has_dep ? 'fr-icon-warning-fill' : undefined,
+  }))
 
   const {
     data: chronique,
@@ -108,7 +89,7 @@ export default function ChroniquesParSubstances({
           <div style={{ maxWidth: 400 }}>
             <SingleSelectMenu
               label="Sélectionnez une substance"
-              options={toSelectOptions(substances ?? [], selectedCode)}
+              options={substanceOptions}
               onChange={(opt) => setSelectedCode(opt.value)}
             />
           </div>

--- a/types/captage.ts
+++ b/types/captage.ts
@@ -16,6 +16,7 @@ export type SubstanceItem = {
   libelle_parametre: string
   code_unite: string
   has_dep: boolean
+  max_value: number
 }
 
 export type SubstanceChroniqueInfo = {


### PR DESCRIPTION
Cette PR propose de trier les substances afin d'atteindre plus rapidement les informations intéressantes.

Les substances listées sont triées de cette façon : 
- en dépassement
- sans dépassement
- non détectée

## Capture : 


https://github.com/user-attachments/assets/009c2c3b-64d4-42a8-bdb8-59df67a17952

