### PR TITLE
Composant UI SingleSelectorMenu

### DIFF
--- a/inertia/ui/SelectorMenu/index.tsx
+++ b/inertia/ui/SelectorMenu/index.tsx
@@ -23,7 +23,7 @@ type GroupHeaderProps = {
 function GroupHeader({ groupName }: GroupHeaderProps) {
   return (
     <div
-      className="fr-px-2v fr-py-1v font-bold text-sm"
+      className="font-bold fr-p-2v"
       style={{
         background: fr.colors.decisions.background.actionHigh.blueFrance.default,
         color: fr.colors.decisions.background.default.grey.default,

--- a/inertia/ui/SingleSelectMenu/index.tsx
+++ b/inertia/ui/SingleSelectMenu/index.tsx
@@ -1,9 +1,8 @@
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, useId } from 'react'
 import { fr } from '@codegouvfr/react-dsfr'
 import { groupBy } from 'lodash-es'
 
 import SingleSelectItem from './single-select-item'
-import { DropdownAction } from '../InputWithSelector/dropdown-item'
 
 export type OptionType<T> = {
   value: T
@@ -11,7 +10,6 @@ export type OptionType<T> = {
   iconId?: string
   isSelected: boolean
   group?: string
-  actions?: DropdownAction<T>[]
 }
 
 export type SingleSelectMenuProps<T extends string | number> = {
@@ -52,7 +50,7 @@ export default function SingleSelectMenu<T extends string | number>({
 }: SingleSelectMenuProps<T>) {
   const [isOpen, setIsOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
-  const triggerId = useRef(`single-select-trigger-${Math.random().toString(36).slice(2)}`)
+  const triggerId = `triggerId-${useId()}`
 
   const selectedOption = options.find((opt) => opt.isSelected)
   const closeDropdown = useCallback(() => setIsOpen(false), [])
@@ -81,7 +79,7 @@ export default function SingleSelectMenu<T extends string | number>({
   return (
     <div ref={containerRef} className="fr-select-group" style={{ marginBottom: 0 }}>
       {label && (
-        <label className="fr-label" htmlFor={triggerId.current}>
+        <label className="fr-label" htmlFor={triggerId}>
           {label}
           {hint && <span className="fr-hint-text">{hint}</span>}
         </label>
@@ -89,7 +87,7 @@ export default function SingleSelectMenu<T extends string | number>({
 
       <div style={{ position: 'relative' }}>
         <button
-          id={triggerId.current}
+          id={triggerId}
           type="button"
           onClick={() => setIsOpen((prev) => !prev)}
           aria-haspopup="listbox"

--- a/inertia/ui/SingleSelectMenu/index.tsx
+++ b/inertia/ui/SingleSelectMenu/index.tsx
@@ -1,0 +1,166 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { fr } from '@codegouvfr/react-dsfr'
+import { groupBy } from 'lodash-es'
+
+import SingleSelectItem from './single-select-item'
+import { DropdownAction } from '../InputWithSelector/dropdown-item'
+
+export type OptionType<T> = {
+  value: T
+  label: string
+  iconId?: string
+  isSelected: boolean
+  group?: string
+  actions?: DropdownAction<T>[]
+}
+
+export type SingleSelectMenuProps<T extends string | number> = {
+  label?: string
+  hint?: string
+  placeholder?: string
+  options: OptionType<T>[]
+  onChange: (option: OptionType<T>) => void
+}
+
+type GroupHeaderProps = {
+  groupName: string
+}
+
+function GroupHeader({ groupName }: GroupHeaderProps) {
+  return (
+    <div
+      className="font-bold fr-p-2v"
+      style={{
+        background: fr.colors.decisions.background.actionHigh.blueFrance.default,
+        color: fr.colors.decisions.background.default.grey.default,
+      }}
+      id={`single-select-group-${groupName}`}
+      role="heading"
+      aria-level={2}
+    >
+      {groupName}
+    </div>
+  )
+}
+
+export default function SingleSelectMenu<T extends string | number>({
+  label,
+  hint,
+  placeholder = 'Sélectionner une option',
+  options,
+  onChange,
+}: SingleSelectMenuProps<T>) {
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const triggerId = useRef(`single-select-trigger-${Math.random().toString(36).slice(2)}`)
+
+  const selectedOption = options.find((opt) => opt.isSelected)
+  const closeDropdown = useCallback(() => setIsOpen(false), [])
+
+  useEffect(() => {
+    function handlePointerDown(event: PointerEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as HTMLElement)) {
+        closeDropdown()
+      }
+    }
+    if (isOpen) {
+      document.addEventListener('pointerdown', handlePointerDown)
+      return () => document.removeEventListener('pointerdown', handlePointerDown)
+    }
+  }, [isOpen, closeDropdown])
+
+  const handleSelect = (value: T) => {
+    const option = options.find((opt) => opt.value === value)
+    if (!option) return
+    onChange({ ...option, isSelected: true })
+    closeDropdown()
+  }
+
+  const optionsByGroup = groupBy(options, (opt) => opt.group ?? '')
+
+  return (
+    <div ref={containerRef} className="fr-select-group" style={{ marginBottom: 0 }}>
+      {label && (
+        <label className="fr-label" htmlFor={triggerId.current}>
+          {label}
+          {hint && <span className="fr-hint-text">{hint}</span>}
+        </label>
+      )}
+
+      <div style={{ position: 'relative' }}>
+        <button
+          id={triggerId.current}
+          type="button"
+          onClick={() => setIsOpen((prev) => !prev)}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
+          className="fr-select"
+          style={{
+            appearance: 'none',
+            WebkitAppearance: 'none',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            textAlign: 'left',
+            cursor: 'pointer',
+          }}
+        >
+          <span
+            style={{
+              color: selectedOption
+                ? fr.colors.decisions.text.default.grey.default
+                : fr.colors.decisions.text.mention.grey.default,
+            }}
+          >
+            {selectedOption ? selectedOption.label : placeholder}
+          </span>
+        </button>
+
+        {isOpen && (
+          <div
+            className="absolute shadow-lg flex flex-col gap-1"
+            style={{
+              top: '100%',
+              left: 0,
+              right: 0,
+              zIndex: 9999,
+              background: fr.colors.decisions.background.default.grey.default,
+              maxHeight: 200,
+              width: '100%',
+              overflowY: 'auto',
+              overflowX: 'hidden',
+            }}
+            role="listbox"
+            aria-label={label}
+          >
+            {options.length > 0 ? (
+              Object.keys(optionsByGroup).map((groupName) => (
+                <div
+                  key={groupName}
+                  role="group"
+                  aria-labelledby={groupName ? `single-select-group-${groupName}` : undefined}
+                >
+                  {groupName && <GroupHeader groupName={groupName} />}
+                  {optionsByGroup[groupName].map((option, index, arr) => (
+                    <SingleSelectItem
+                      key={option.value}
+                      item={option}
+                      iconId={option.iconId}
+                      isLast={index === arr.length - 1}
+                      onSelect={handleSelect}
+                    />
+                  ))}
+                </div>
+              ))
+            ) : (
+              <div className="w-full italic text-center fr-p-2v" role="option" aria-disabled="true">
+                Aucune option disponible
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/inertia/ui/SingleSelectMenu/single-select-item.tsx
+++ b/inertia/ui/SingleSelectMenu/single-select-item.tsx
@@ -1,0 +1,48 @@
+import { fr } from '@codegouvfr/react-dsfr'
+import { OptionType } from './index'
+
+export type SingleSelectItemProps<T extends string | number> = {
+  item: OptionType<T>
+  iconId?: string
+  isLast?: boolean
+  onSelect: (value: T) => void
+}
+
+export default function SingleSelectItem<T extends string | number>({
+  item,
+  iconId,
+  isLast,
+  onSelect,
+}: SingleSelectItemProps<T>) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.value)}
+      className="flex items-center justify-between fr-p-2v w-full"
+      style={{
+        borderBottom: isLast
+          ? 'none'
+          : `solid 1px ${fr.colors.decisions.border.default.grey.default}`,
+        color: item.isSelected
+          ? fr.colors.decisions.text.actionHigh.blueFrance.default
+          : fr.colors.decisions.text.default.grey.default,
+        textAlign: 'left',
+        cursor: 'pointer',
+      }}
+      role="option"
+      aria-selected={item.isSelected}
+    >
+      <div className="flex items-center gap-2">
+        {iconId && <span className={`${iconId} fr-icon--sm flex items-center`} />}
+        <span>{item.label}</span>
+      </div>
+      {item.isSelected && (
+        <span
+          className="fr-icon-check-line fr-icon--sm"
+          aria-hidden="true"
+          style={{ color: fr.colors.decisions.text.actionHigh.blueFrance.default }}
+        />
+      )}
+    </button>
+  )
+}

--- a/inertia/ui/SingleSelectMenu/single-select-menu.stories.tsx
+++ b/inertia/ui/SingleSelectMenu/single-select-menu.stories.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import SingleSelectMenu, { SingleSelectMenuProps, OptionType } from './index'
+
+const meta = {
+  title: 'UI/SingleSelectMenu',
+  component: SingleSelectMenu,
+  tags: ['autodocs'],
+  decorators: [
+    (Story: React.ComponentType) => (
+      <div style={{ height: '250px', maxWidth: '400px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Libellé affiché au-dessus du sélecteur.',
+    },
+    hint: {
+      control: 'text',
+      description: 'Texte indicatif affiché sous le libellé.',
+    },
+    iconId: {
+      control: 'text',
+      description: 'Identifiant de l’icône à afficher à gauche du label de chaque option.',
+    },
+    placeholder: {
+      control: 'text',
+      description: "Texte affiché dans le déclencheur quand aucune option n'est sélectionnée.",
+    },
+    options: {
+      control: 'object',
+      description:
+        'Liste des options. Une seule peut avoir `isSelected: true`.\n\nModèle :\n[\n  {\n    value: string | number,\n    label: string,\n    isSelected: boolean,\n    group?: string,\n  }\n]',
+    },
+    onChange: {
+      control: false,
+      description: "Callback appelé lors de la sélection d'une option.",
+    },
+  },
+  args: {} as SingleSelectMenuProps<string>,
+}
+
+export default meta
+
+export const Défaut = () => {
+  const [options, setOptions] = useState<OptionType<string>[]>([
+    { value: 'option1', label: 'Option 1', isSelected: false },
+    { value: 'option2', label: 'Option 2', isSelected: false },
+    { value: 'option3', label: 'Option 3', isSelected: false },
+    { value: 'option4', label: 'Option 4', isSelected: false },
+    { value: 'option5', label: 'Option 5', isSelected: false },
+    { value: 'option6', label: 'Option 6', isSelected: false },
+    { value: 'option7', label: 'Option 7', isSelected: false },
+    { value: 'option8', label: 'Option 8', isSelected: false },
+    { value: 'option9', label: 'Option 9', isSelected: false },
+  ])
+
+  const handleChange = (selected: OptionType<string>) => {
+    setOptions((prev) => prev.map((opt) => ({ ...opt, isSelected: opt.value === selected.value })))
+  }
+
+  return <SingleSelectMenu label="Choisir une option" options={options} onChange={handleChange} />
+}
+
+export const AvecSélectionInitiale = () => {
+  const [options, setOptions] = useState<OptionType<string>[]>([
+    { value: 'option1', label: 'Option 1', isSelected: false },
+    { value: 'option2', label: 'Option 2', isSelected: true },
+    { value: 'option3', label: 'Option 3', isSelected: false },
+  ])
+
+  const handleChange = (selected: OptionType<string>) => {
+    setOptions((prev) => prev.map((opt) => ({ ...opt, isSelected: opt.value === selected.value })))
+  }
+
+  return (
+    <SingleSelectMenu
+      label="Choisir une option"
+      hint="Une option est présélectionnée"
+      options={options}
+      onChange={handleChange}
+    />
+  )
+}
+
+export const AvecIcônes = () => {
+  const [options, setOptions] = useState<OptionType<string>[]>([
+    { value: 'option1', label: 'Option 1', isSelected: false, iconId: 'fr-icon-warning-fill' },
+    { value: 'option2', label: 'Option 2', isSelected: false, iconId: 'fr-icon-error-fill' },
+    { value: 'option3', label: 'Option 3', isSelected: false, iconId: 'fr-icon-info-fill' },
+  ])
+
+  const handleChange = (selected: OptionType<string>) => {
+    setOptions((prev) => prev.map((opt) => ({ ...opt, isSelected: opt.value === selected.value })))
+  }
+
+  return <SingleSelectMenu label="Choisir une option" options={options} onChange={handleChange} />
+}
+
+export const AvecGroupes = () => {
+  const [options, setOptions] = useState<OptionType<string>[]>([
+    { value: 'fr', label: 'France', isSelected: false, group: 'Europe' },
+    { value: 'de', label: 'Allemagne', isSelected: false, group: 'Europe' },
+    { value: 'es', label: 'Espagne', isSelected: false, group: 'Europe' },
+    { value: 'ma', label: 'Maroc', isSelected: false, group: 'Afrique' },
+    { value: 'sn', label: 'Sénégal', isSelected: false, group: 'Afrique' },
+  ])
+
+  const handleChange = (selected: OptionType<string>) => {
+    setOptions((prev) => prev.map((opt) => ({ ...opt, isSelected: opt.value === selected.value })))
+  }
+
+  return <SingleSelectMenu label="Sélectionner un pays" options={options} onChange={handleChange} />
+}
+
+export const SansLibellé = () => {
+  const [options, setOptions] = useState<OptionType<string>[]>([
+    { value: 'option1', label: 'Option 1', isSelected: false },
+    { value: 'option2', label: 'Option 2', isSelected: false },
+    { value: 'option3', label: 'Option 3', isSelected: false },
+  ])
+
+  const handleChange = (selected: OptionType<string>) => {
+    setOptions((prev) => prev.map((opt) => ({ ...opt, isSelected: opt.value === selected.value })))
+  }
+
+  return (
+    <SingleSelectMenu placeholder="Filtrer par statut…" options={options} onChange={handleChange} />
+  )
+}
+
+export const SansOptions = () => {
+  return <SingleSelectMenu label="Choisir une option" options={[]} onChange={() => {}} />
+}

--- a/inertia/ui/SingleSelectMenu/single-select-menu.stories.tsx
+++ b/inertia/ui/SingleSelectMenu/single-select-menu.stories.tsx
@@ -21,10 +21,6 @@ const meta = {
       control: 'text',
       description: 'Texte indicatif affiché sous le libellé.',
     },
-    iconId: {
-      control: 'text',
-      description: 'Identifiant de l’icône à afficher à gauche du label de chaque option.',
-    },
     placeholder: {
       control: 'text',
       description: "Texte affiché dans le déclencheur quand aucune option n'est sélectionnée.",
@@ -32,7 +28,7 @@ const meta = {
     options: {
       control: 'object',
       description:
-        'Liste des options. Une seule peut avoir `isSelected: true`.\n\nModèle :\n[\n  {\n    value: string | number,\n    label: string,\n    isSelected: boolean,\n    group?: string,\n  }\n]',
+        "Liste des options. Une seule peut avoir `isSelected: true`.\n\nModèle :\n[\n  {\n    value: string | number,\n    label: string,\n    isSelected: boolean,\n    iconId?: string,  // identifiant de l'icône à afficher à gauche du label\n    group?: string,\n  }\n]",
     },
     onChange: {
       control: false,


### PR DESCRIPTION
Cette pull request introduit un nouveau composant UI `SingleSelectMenu`, accessible et personnalisable, permettant de sélectionner une seule option parmi une liste, avec prise en charge des groupes, des icônes et des actions personnalisées. Elle inclut également un ensemble de stories Storybook pour démontrer et tester le composant, ainsi qu’une légère mise à jour de style du `GroupHeader` pour assurer une meilleure cohérence visuelle.

## Nouveau composant `SingleSelectMenu` et fonctionnalités associées

* Ajout d’un nouveau composant générique `SingleSelectMenu` dans `inertia/ui/SingleSelectMenu/index.tsx`, prenant en charge les options groupées, les icônes, l’accessibilité clavier et pointeur, ainsi que les actions personnalisées. Le composant utilise un bouton déclencheur pour afficher une liste déroulante d’options et appelle `onChange` lorsqu’une option est sélectionnée.
* Ajout d’un sous-composant `SingleSelectItem` pour afficher les options individuelles avec des icônes optionnelles et un état de sélection.
* Ajout de stories.
<img width="403" height="276" alt="Capture d’écran 2026-05-18 à 11 29 05" src="https://github.com/user-attachments/assets/b5db2352-228c-454a-bff7-705ed0d40b9f" />

## Améliorations de style

* Mise à jour du style du `GroupHeader` dans le nouveau composant ainsi que dans `inertia/ui/SelectorMenu/index.tsx` pour garantir une cohérence visuelle.

Close #408 