### PR TITLE
Création de nouveaux territoires depuis la CLI.

### DIFF
--- a/app/services/territoire_service.ts
+++ b/app/services/territoire_service.ts
@@ -1,0 +1,17 @@
+import Territoire from '#models/territoire'
+
+export class TerritoireService {
+  async createTerritoire(name: string) {
+    const trimmedName = name.trim()
+
+    if (!trimmedName) {
+      throw new Error('Territoire name cannot be empty')
+    }
+
+    return Territoire.create({
+      name: trimmedName,
+      code: null,
+      parentTerritoireId: null,
+    })
+  }
+}

--- a/commands/territoire_create.ts
+++ b/commands/territoire_create.ts
@@ -1,6 +1,7 @@
 import { args, BaseCommand } from '@adonisjs/core/ace'
 import type { CommandOptions } from '@adonisjs/core/types/ace'
 import { TerritoireService } from '#services/territoire_service'
+import Territoire from '#models/territoire'
 
 export default class TerritoireCreate extends BaseCommand {
   static commandName = 'territoire:create'
@@ -15,6 +16,13 @@ export default class TerritoireCreate extends BaseCommand {
 
   async run() {
     try {
+      const existingTerritoire = await Territoire.findBy('name', this.name.trim())
+      if (existingTerritoire) {
+        this.logger.error(`A territoire with the name "${this.name.trim()}" already exists`)
+        this.exitCode = 1
+        return
+      }
+
       const territoire = await new TerritoireService().createTerritoire(this.name)
 
       this.logger.success(`Territoire "${territoire.name}" created with id "${territoire.id}"`)

--- a/commands/territoire_create.ts
+++ b/commands/territoire_create.ts
@@ -1,0 +1,26 @@
+import { args, BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import { TerritoireService } from '#services/territoire_service'
+
+export default class TerritoireCreate extends BaseCommand {
+  static commandName = 'territoire:create'
+  static description = 'Create a new territoire'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  @args.string({ description: 'Name of the territoire to create' })
+  declare name: string
+
+  async run() {
+    try {
+      const territoire = await new TerritoireService().createTerritoire(this.name)
+
+      this.logger.success(`Territoire "${territoire.name}" created with id "${territoire.id}"`)
+    } catch (error) {
+      this.logger.error(error instanceof Error ? error.message : 'Failed to create territoire')
+      this.exitCode = 1
+    }
+  }
+}

--- a/database/factories/territoire_factory.ts
+++ b/database/factories/territoire_factory.ts
@@ -6,10 +6,10 @@ export const TerritoireFactory = factory
   .define(Territoire, async () => {
     return {
       name: faker.location.county(),
-      code: faker.helpers.arrayElement([
-        faker.string.numeric({ length: { min: 1, max: 10 } }),
-        null,
-      ]),
+      code: faker.string.numeric({ length: { min: 1, max: 10 } }),
     }
+  })
+  .state('nonAAC', (territoire) => {
+    territoire.code = null
   })
   .build()

--- a/database/factories/territoire_factory.ts
+++ b/database/factories/territoire_factory.ts
@@ -6,7 +6,10 @@ export const TerritoireFactory = factory
   .define(Territoire, async () => {
     return {
       name: faker.location.county(),
-      code: faker.string.numeric({ length: { min: 1, max: 10 } }),
+      code: faker.helpers.arrayElement([
+        faker.string.numeric({ length: { min: 1, max: 10 } }),
+        null,
+      ]),
     }
   })
   .build()

--- a/database/seeders/8_assign_territoire_seeder.ts
+++ b/database/seeders/8_assign_territoire_seeder.ts
@@ -3,17 +3,26 @@ import User from '#models/user'
 import Territoire from '#models/territoire'
 import Env from '#start/env'
 
+// This seeder assigns territoires to users based on the USERS_TO_SEED environment variable.
+// The variable must respect the EnvUserSeeds type.
+// territoireCodes is useful for AACs from the SANDRE national referential, while territoireIds can be used for any existing territoires.
+// If both territoireCodes and territoireIds are present, both are read.
+
+type EnvUserSeeds = Array<{
+  email: string
+  // AAC Codes
+  territoireCodes?: string[]
+  // Territoire UUIDs
+  territoireIds?: string[]
+}>
+
 export default class extends BaseSeeder {
   async run() {
-    // Read the environment to find territoire codes
-    const usersToSeed: Array<{ email: string; territoireCodes?: string[] }> = JSON.parse(
-      Env.get('USERS_TO_SEED') || '[]'
-    )
+    // Read the environment to find territoires
+    const usersToSeed: EnvUserSeeds = JSON.parse(Env.get('USERS_TO_SEED') || '[]')
 
     for (const userData of usersToSeed) {
-      if (!userData.territoireCodes?.length) continue
-
-      userData.email = userData.email.toLowerCase()
+      userData.email = userData.email.toLowerCase().trim()
 
       const user = await User.findBy('email', userData.email)
       if (!user) {
@@ -21,19 +30,40 @@ export default class extends BaseSeeder {
         continue
       }
 
-      const territoires = await Territoire.query().whereIn('code', userData.territoireCodes)
-      const notFound = userData.territoireCodes.filter(
-        (c) => !territoires.some((t) => t.code === c)
-      )
-      if (notFound.length > 0) {
-        console.warn(`Territoire codes not found: ${notFound.join(', ')}`)
-      }
+      if (userData.territoireCodes && userData.territoireCodes.length > 0) {
+        const territoires = await Territoire.query().whereIn('code', userData.territoireCodes)
+        const notFound = userData.territoireCodes.filter(
+          (c) => !territoires.some((t) => t.code === c)
+        )
+        if (notFound.length > 0) {
+          console.warn(`Territoire codes not found: ${notFound.join(', ')}`)
+        }
 
-      await user.related('territoires').sync(
-        territoires.map((t) => t.id),
-        false
-      )
-      console.info(`Assigned ${territoires.length} territoire(s) to "${userData.email}"`)
+        // The sync method ensures the relations are up to date with the env var value
+        await user.related('territoires').sync(
+          territoires.map((t) => t.id),
+          false
+        )
+        console.info(
+          `Assigned ${territoires.length} territoire(s) to "${userData.email}" based on their AAC codes.`
+        )
+      }
+      if (userData.territoireIds && userData.territoireIds.length > 0) {
+        const territoires = await Territoire.query().whereIn('id', userData.territoireIds)
+        const notFound = userData.territoireIds.filter((c) => !territoires.some((t) => t.id === c))
+        if (notFound.length > 0) {
+          console.warn(`Territoire ids not found: ${notFound.join(', ')}`)
+        }
+
+        // The sync method ensures the relations are up to date with the env var value
+        await user.related('territoires').sync(
+          territoires.map((t) => t.id),
+          false
+        )
+        console.info(
+          `Assigned ${territoires.length} territoire(s) to "${userData.email}" based on their ids.`
+        )
+      }
     }
   }
 }

--- a/database/seeders/8_assign_territoire_seeder.ts
+++ b/database/seeders/8_assign_territoire_seeder.ts
@@ -30,6 +30,8 @@ export default class extends BaseSeeder {
         continue
       }
 
+      const territoiresIdsToSync = new Set<string>()
+
       if (userData.territoireCodes && userData.territoireCodes.length > 0) {
         const territoires = await Territoire.query().whereIn('code', userData.territoireCodes)
         const notFound = userData.territoireCodes.filter(
@@ -39,14 +41,9 @@ export default class extends BaseSeeder {
           console.warn(`Territoire codes not found: ${notFound.join(', ')}`)
         }
 
-        // The sync method ensures the relations are up to date with the env var value
-        await user.related('territoires').sync(
-          territoires.map((t) => t.id),
-          false
-        )
-        console.info(
-          `Assigned ${territoires.length} territoire(s) to "${userData.email}" based on their AAC codes.`
-        )
+        for (const territoire of territoires) {
+          territoiresIdsToSync.add(territoire.id)
+        }
       }
       if (userData.territoireIds && userData.territoireIds.length > 0) {
         const territoires = await Territoire.query().whereIn('id', userData.territoireIds)
@@ -55,15 +52,16 @@ export default class extends BaseSeeder {
           console.warn(`Territoire ids not found: ${notFound.join(', ')}`)
         }
 
-        // The sync method ensures the relations are up to date with the env var value
-        await user.related('territoires').sync(
-          territoires.map((t) => t.id),
-          false
-        )
-        console.info(
-          `Assigned ${territoires.length} territoire(s) to "${userData.email}" based on their ids.`
-        )
+        for (const territoire of territoires) {
+          territoiresIdsToSync.add(territoire.id)
+        }
       }
+
+      // The sync method ensures the relations are up to date with the env var value
+      await user.related('territoires').sync(territoiresIdsToSync.values().toArray(), false)
+      console.info(
+        `Assigned ${territoiresIdsToSync.size} territoire(s) to "${userData.email}" based on their ids.`
+      )
     }
   }
 }

--- a/tests/unit/territoire/territoire_service.spec.ts
+++ b/tests/unit/territoire/territoire_service.spec.ts
@@ -1,0 +1,29 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { TerritoireService } from '#services/territoire_service'
+import Territoire from '#models/territoire'
+
+test.group('Territoire service', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('it creates a territoire from a name', async ({ assert }) => {
+    const territoireService = new TerritoireService()
+
+    const territoire = await territoireService.createTerritoire('  New territoire  ')
+    const persistedTerritoire = await Territoire.findOrFail(territoire.id)
+
+    assert.exists(territoire.id)
+    assert.equal(persistedTerritoire.name, 'New territoire')
+    assert.isNull(persistedTerritoire.code)
+    assert.isNull(persistedTerritoire.parentTerritoireId)
+  })
+
+  test('it rejects an empty territoire name', async ({ assert }) => {
+    const territoireService = new TerritoireService()
+
+    await assert.rejects(
+      () => territoireService.createTerritoire('   '),
+      'Territoire name cannot be empty'
+    )
+  })
+})


### PR DESCRIPTION
Nous avons découvert un problème en production, beaucoup d'utilisateurs potentiels travaillent sur des AACs non référencées dans le réferentiel national Sandre, or Vizeau ne peut fonctionner si un animateur n'est pas assigné à au moins un territoire.

Cette PR propose un moyen facile de créer des territoires non-AAC en production avec seulement un nom afin de débloquer la situation. 

Elle remanie aussi le seeder d'assignation de territoire aux utilisateurs pour qu'on puisse cibler les territoires par identifiant UUID et non seulement par code. Les territoires AAC de Sandre ont toujours un code, les territoires non-AAC n'ont jamais de code.

Closes #411 