### PR TITLE
Ameliorer le design du suivi de la qualité de l'eau

### DIFF
--- a/inertia/components/captage/captage-analyses-header.tsx
+++ b/inertia/components/captage/captage-analyses-header.tsx
@@ -3,11 +3,11 @@ import { fr } from '@codegouvfr/react-dsfr'
 import Loader from '~/ui/Loader'
 import ResumeCard from '~/ui/ResumeCard'
 import { SegmentedControl } from '@codegouvfr/react-dsfr/SegmentedControl'
-import VerticalChartBar from '~/ui/Charts/VerticalChartBar'
 import ChroniquesParSubstances from './chroniques-par-substances'
 import DualRangeSlider from './dual-range-slider'
 import { useFetch } from '~/hooks/use-fetch'
 import type { AnalysesStats, AnalysesPerYear } from '#types/captage'
+import QualiteSuivi from './qualite-suivi'
 
 type Props = {
   aacCode: string
@@ -20,7 +20,6 @@ export default function CaptageAnalysesHeader({ aacCode, installationCode }: Pro
   const [yearMin, setYearMin] = useState<number | null>(null)
   const [yearMax, setYearMax] = useState<number | null>(null)
   const [activeSection, setActiveSection] = useState<'suivi' | 'chroniques'>('suivi')
-  const [activeView, setActiveView] = useState<'graphique' | 'tableau'>('graphique')
 
   const baseUrl = `/aac/${aacCode}/installations/${installationCode}/analyses`
   const yearParams =
@@ -92,47 +91,6 @@ export default function CaptageAnalysesHeader({ aacCode, installationCode }: Pro
     )
   }
 
-  const handleExportCsv = () => {
-    if (!perYearData) return
-    const header = 'Année,Conformes,En dépassement,Total'
-    const rows = perYearData.map((d) => `${d.annee},${d.sans_dep},${d.avec_dep},${d.total}`)
-    const csv = [header, ...rows].join('\n')
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `qualite-eau-${installationCode}.csv`
-    a.style.visibility = 'hidden'
-    document.body.append(a)
-    a.click()
-    a.remove()
-    URL.revokeObjectURL(url)
-  }
-
-  const chartItems =
-    perYearData && perYearData.length > 0
-      ? {
-          labels: perYearData.map((d) => String(d.annee)),
-          datasets: [
-            {
-              label: 'Analyses conformes',
-              data: perYearData.map((d) => d.sans_dep),
-              backgroundColor: '#003189',
-            },
-            {
-              label: 'Analyses en dépassement',
-              data: perYearData.map((d) => d.avec_dep),
-              backgroundColor: '#D40000',
-            },
-          ],
-          tooltipExtras: [
-            { label: "Nombre d'analyses", data: perYearData.map((d) => d.total) },
-            { label: 'Dont en dépassement', data: perYearData.map((d) => d.avec_dep) },
-            { label: 'Conformes', data: perYearData.map((d) => d.sans_dep) },
-          ],
-        }
-      : null
-
   return (
     <div className="flex flex-col gap-4">
       {/* Year range selector + stat boxes */}
@@ -201,7 +159,7 @@ export default function CaptageAnalysesHeader({ aacCode, installationCode }: Pro
 
       {/* Section tabs */}
       <div>
-        <div className="fr-px-3w fr-py-2w">
+        <div className="fr-py-2w">
           <SegmentedControl
             hideLegend
             segments={[
@@ -223,156 +181,22 @@ export default function CaptageAnalysesHeader({ aacCode, installationCode }: Pro
           />
         </div>
 
-        <div style={{ border: `1px solid ${fr.colors.decisions.border.default.grey.default}` }}>
+        <div>
           {activeSection === 'suivi' && (
-            <div className="fr-p-3w flex flex-col gap-4">
-              <div className="flex items-start gap-2">
-                <span
-                  className="fr-icon-bar-chart-fill fr-icon--md"
-                  aria-hidden="true"
-                  style={{
-                    color: fr.colors.decisions.text.label.blueFrance.default,
-                    flexShrink: 0,
-                    marginTop: 2,
-                  }}
-                />
-                <div>
-                  <h6 className="fr-text--md fr-mb-1v" style={{ fontWeight: 700 }}>
-                    Suivi de la qualité de l'eau
-                  </h6>
-                  <p
-                    className="fr-text--sm fr-mb-0"
-                    style={{ color: fr.colors.decisions.text.mention.grey.default }}
-                  >
-                    Consulter sur un nombre d'analyses données, l'évolution des dépassements par
-                    années
-                  </p>
-                </div>
-              </div>
-
-              {/* Segmented control + exporter */}
-              <div
-                className="flex items-center justify-between fr-px-3w fr-py-2w"
-                style={{
-                  backgroundColor: fr.colors.decisions.background.alt.blueFrance.default,
-                }}
-              >
-                <SegmentedControl
-                  hideLegend
-                  segments={[
-                    {
-                      label: 'Graphique',
-                      nativeInputProps: {
-                        checked: activeView === 'graphique',
-                        onChange: () => setActiveView('graphique'),
-                      },
-                    },
-                    {
-                      label: 'Tableau',
-                      nativeInputProps: {
-                        checked: activeView === 'tableau',
-                        onChange: () => setActiveView('tableau'),
-                      },
-                    },
-                  ]}
-                />
-                <button
-                  className="fr-btn fr-btn--sm fr-icon-download-line fr-btn--icon-left"
-                  onClick={handleExportCsv}
-                  disabled={!perYearData || perYearData.length === 0}
-                  type="button"
-                >
-                  Exporter
-                </button>
-              </div>
-
-              {/* Content */}
-              {loadingPerYear ? (
-                <div className="flex items-center gap-2 fr-py-3w">
-                  <Loader type="dots" size="sm" />
-                </div>
-              ) : !perYearData || perYearData.length === 0 ? (
-                <p
-                  className="fr-text--sm fr-mb-0"
-                  style={{ color: fr.colors.decisions.text.mention.grey.default }}
-                >
-                  Aucune donnée disponible pour cette période.
-                </p>
-              ) : activeView === 'graphique' ? (
-                chartItems && (
-                  <VerticalChartBar
-                    chartItems={chartItems}
-                    yAxisLabel="Nombre d'analyses"
-                    unit="analyse(s)"
-                    chartHeight={350}
-                  />
-                )
-              ) : (
-                <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-                  <thead>
-                    <tr
-                      style={{
-                        backgroundColor: fr.colors.decisions.background.default.grey.default,
-                        borderBottom: `2px solid ${fr.colors.decisions.border.default.grey.default}`,
-                      }}
-                    >
-                      {['Année', 'Conformes', 'En dépassement', 'Total'].map((col) => (
-                        <th
-                          key={col}
-                          scope="col"
-                          style={{
-                            padding: '10px 16px',
-                            textAlign: 'left',
-                            fontWeight: 700,
-                            fontSize: 14,
-                          }}
-                        >
-                          {col}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {perYearData.map((d) => (
-                      <tr
-                        key={d.annee}
-                        style={{
-                          borderBottom: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
-                        }}
-                      >
-                        <td style={{ padding: '10px 16px', fontSize: 14 }}>{d.annee}</td>
-                        <td style={{ padding: '10px 16px', fontSize: 14 }}>
-                          {d.sans_dep.toLocaleString('fr-FR')}
-                        </td>
-                        <td style={{ padding: '10px 16px', fontSize: 14 }}>
-                          {d.avec_dep > 0 ? (
-                            <span style={{ color: fr.colors.decisions.text.default.error.default }}>
-                              {d.avec_dep.toLocaleString('fr-FR')}
-                            </span>
-                          ) : (
-                            d.avec_dep.toLocaleString('fr-FR')
-                          )}
-                        </td>
-                        <td style={{ padding: '10px 16px', fontSize: 14 }}>
-                          {d.total.toLocaleString('fr-FR')}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              )}
-            </div>
+            <QualiteSuivi
+              perYearData={perYearData}
+              installationCode={installationCode}
+              loadingPerYear={loadingPerYear}
+            />
           )}
 
           {activeSection === 'chroniques' && yearMin !== null && yearMax !== null && (
-            <div className="fr-p-3w">
-              <ChroniquesParSubstances
-                aacCode={aacCode}
-                installationCode={installationCode}
-                yearMin={yearMin}
-                yearMax={yearMax}
-              />
-            </div>
+            <ChroniquesParSubstances
+              aacCode={aacCode}
+              installationCode={installationCode}
+              yearMin={yearMin}
+              yearMax={yearMax}
+            />
           )}
         </div>
       </div>

--- a/inertia/components/captage/captage-analyses-header.tsx
+++ b/inertia/components/captage/captage-analyses-header.tsx
@@ -128,22 +128,22 @@ export default function CaptageAnalysesHeader({ aacCode, installationCode }: Pro
         {/* Stats boxes: 2 on top, 1 bottom-left */}
         <div className="grid grid-cols-2 gap-3 fr-mt-3w">
           <ResumeCard
+            title="Dépassements réglementaires"
+            iconId="fr-icon-error-line"
+            color={fr.colors.decisions.text.default.error.default}
+            value={
+              loadingStats
+                ? null
+                : (stats?.depassements_reglementaires?.toLocaleString('fr-FR') ?? null)
+            }
+            label="au total sur la période"
+          />
+          <ResumeCard
             title="Dépassements d'alerte (80 %)"
             iconId="fr-icon-warning-line"
             color={fr.colors.decisions.text.default.warning.default}
             value={
               loadingStats ? null : (stats?.depassements_alerte?.toLocaleString('fr-FR') ?? null)
-            }
-            label="au total sur la période"
-          />
-          <ResumeCard
-            title="Dépassements réglementaires"
-            iconId="fr-icon-information-line"
-            color={fr.colors.decisions.text.label.blueFrance.default}
-            value={
-              loadingStats
-                ? null
-                : (stats?.depassements_reglementaires?.toLocaleString('fr-FR') ?? null)
             }
             label="au total sur la période"
           />

--- a/inertia/components/captage/chroniques-par-substances.tsx
+++ b/inertia/components/captage/chroniques-par-substances.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import Select from '@codegouvfr/react-dsfr/Select'
+import SingleSelectMenu, { OptionType } from '~/ui/SingleSelectMenu'
 import Loader from '~/ui/Loader'
 import type { SubstanceItem, ChroniqueData } from '#types/captage'
 import { useFetch } from '~/hooks/use-fetch'
@@ -54,25 +54,24 @@ export default function ChroniquesParSubstances({
     )
   }
 
+  const substanceOptions: OptionType<number>[] = (substances ?? [])
+    .filter((s) => s.code_parametre !== null)
+    .map((s) => ({
+      value: s.code_parametre,
+      label: `${s.libelle_parametre} ${s.has_dep ? '⚠' : ''}`,
+      iconId: s.has_dep ? 'fr-icon-warning-line' : undefined,
+      isSelected: s.code_parametre === selectedCode,
+    }))
+
   const substanceSelector = loadingSubstances ? (
     <Loader type="dots" size="sm" />
   ) : (
-    <Select
-      label=""
-      nativeSelectProps={{
-        id: 'substance-select',
-        value: selectedCode ?? '',
-        onChange: (e) => setSelectedCode(Number(e.target.value)),
-      }}
-      style={{ marginBottom: 0, maxWidth: '50%' }}
-    >
-      {(substances ?? []).map((s) => (
-        <option key={s.code_parametre} value={s.code_parametre}>
-          {s.libelle_parametre}
-          {s.has_dep ? ' ⚠' : ''}
-        </option>
-      ))}
-    </Select>
+    <div className="w-[300px]">
+      <SingleSelectMenu
+        options={substanceOptions}
+        onChange={(option) => setSelectedCode(option.value)}
+      />
+    </div>
   )
 
   return (

--- a/inertia/components/captage/chroniques-par-substances.tsx
+++ b/inertia/components/captage/chroniques-par-substances.tsx
@@ -58,7 +58,7 @@ export default function ChroniquesParSubstances({
     .filter((s) => s.code_parametre !== null)
     .map((s) => ({
       value: s.code_parametre,
-      label: `${s.libelle_parametre} ${s.has_dep ? '⚠' : ''}`,
+      label: s.libelle_parametre,
       iconId: s.has_dep ? 'fr-icon-warning-line' : undefined,
       isSelected: s.code_parametre === selectedCode,
     }))

--- a/inertia/components/captage/chroniques-par-substances.tsx
+++ b/inertia/components/captage/chroniques-par-substances.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { fr } from '@codegouvfr/react-dsfr'
 import Select from '@codegouvfr/react-dsfr/Select'
 import Loader from '~/ui/Loader'
 import type { SubstanceItem, ChroniqueData } from '#types/captage'
@@ -55,42 +54,32 @@ export default function ChroniquesParSubstances({
     )
   }
 
+  const substanceSelector = loadingSubstances ? (
+    <Loader type="dots" size="sm" />
+  ) : (
+    <Select
+      label=""
+      nativeSelectProps={{
+        id: 'substance-select',
+        value: selectedCode ?? '',
+        onChange: (e) => setSelectedCode(Number(e.target.value)),
+      }}
+      style={{ marginBottom: 0, maxWidth: '50%' }}
+    >
+      {(substances ?? []).map((s) => (
+        <option key={s.code_parametre} value={s.code_parametre}>
+          {s.libelle_parametre}
+          {s.has_dep ? ' ⚠' : ''}
+        </option>
+      ))}
+    </Select>
+  )
+
   return (
-    <div className="flex flex-col gap-4">
-      {/* Substance selector */}
-      <div
-        className="fr-px-3w fr-py-2w"
-        style={{ backgroundColor: fr.colors.decisions.background.alt.blueFrance.default }}
-      >
-        {loadingSubstances ? (
-          <Loader type="dots" size="sm" />
-        ) : (
-          <Select
-            label="Sélectionnez une substance"
-            nativeSelectProps={{
-              id: 'substance-select',
-              value: selectedCode ?? '',
-              onChange: (e) => setSelectedCode(Number(e.target.value)),
-            }}
-            style={{ marginBottom: 0, maxWidth: 400 }}
-          >
-            {(substances ?? []).map((s) => (
-              <option key={s.code_parametre} value={s.code_parametre}>
-                {s.libelle_parametre}
-                {s.has_dep ? ' ⚠' : ''}
-              </option>
-            ))}
-          </Select>
-        )}
-      </div>
-
-      {loadingChronique && (
-        <div className="flex items-center gap-2 fr-py-2w">
-          <Loader type="dots" size="sm" />
-        </div>
-      )}
-
-      {!loadingChronique && chronique && <SubstanceDetail chronique={chronique} />}
-    </div>
+    <SubstanceDetail
+      chronique={chronique ?? null}
+      loading={loadingChronique}
+      headerContent={substanceSelector}
+    />
   )
 }

--- a/inertia/components/captage/qualite-suivi.tsx
+++ b/inertia/components/captage/qualite-suivi.tsx
@@ -72,7 +72,7 @@ export default function QualiteSuivi({
     <SectionCard
       title="Suivi de la qualité de l'eau"
       icon="fr-icon-bar-chart-fill"
-      caption="Consulter sur un nombre d'analyses données, l'évolution des dépassements par années."
+      caption="Consulter, pour un nombre donné d'analyses, l'évolution des dépassements par année."
       size="small"
     >
       {/* Segmented control + exporter */}

--- a/inertia/components/captage/qualite-suivi.tsx
+++ b/inertia/components/captage/qualite-suivi.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react'
+import { fr } from '@codegouvfr/react-dsfr'
+
+import { SegmentedControl } from '@codegouvfr/react-dsfr/SegmentedControl'
+import { Table } from '@codegouvfr/react-dsfr/Table'
+import Button from '@codegouvfr/react-dsfr/Button'
+import Loader from '~/ui/Loader'
+import VerticalChartBar from '~/ui/Charts/VerticalChartBar'
+import SectionCard from '~/ui/SectionCard'
+
+export type QualiteSuiviProps = {
+  perYearData:
+    | {
+        annee: number
+        sans_dep: number
+        avec_dep: number
+        total: number
+      }[]
+    | null
+  installationCode: string
+  loadingPerYear: boolean
+}
+export default function QualiteSuivi({
+  perYearData,
+  installationCode,
+  loadingPerYear,
+}: QualiteSuiviProps) {
+  const [activeView, setActiveView] = useState<'graphique' | 'tableau'>('graphique')
+
+  const handleExportCsv = () => {
+    if (!perYearData) return
+    const header = 'Année,Conformes,En dépassement,Total'
+    const rows = perYearData.map((d) => `${d.annee},${d.sans_dep},${d.avec_dep},${d.total}`)
+    const csv = [header, ...rows].join('\n')
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `qualite-eau-${installationCode}.csv`
+    a.style.visibility = 'hidden'
+    document.body.append(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+  }
+
+  const chartItems =
+    perYearData && perYearData.length > 0
+      ? {
+          labels: perYearData.map((d) => String(d.annee)),
+          datasets: [
+            {
+              label: 'Analyses conformes',
+              data: perYearData.map((d) => d.sans_dep),
+              backgroundColor: '#003189',
+            },
+            {
+              label: 'Analyses en dépassement',
+              data: perYearData.map((d) => d.avec_dep),
+              backgroundColor: '#D40000',
+            },
+          ],
+          tooltipExtras: [
+            { label: "Nombre d'analyses", data: perYearData.map((d) => d.total) },
+            { label: 'Dont en dépassement', data: perYearData.map((d) => d.avec_dep) },
+            { label: 'Conformes', data: perYearData.map((d) => d.sans_dep) },
+          ],
+        }
+      : null
+
+  return (
+    <SectionCard
+      title="Suivi de la qualité de l'eau"
+      icon="fr-icon-bar-chart-fill"
+      caption="Consulter sur un nombre d'analyses données, l'évolution des dépassements par années."
+      size="small"
+    >
+      {/* Segmented control + exporter */}
+      <div
+        className="flex items-center justify-between fr-px-3w fr-py-2w"
+        style={{
+          backgroundColor: fr.colors.decisions.background.alt.blueFrance.default,
+        }}
+      >
+        <SegmentedControl
+          hideLegend
+          segments={[
+            {
+              label: 'Graphique',
+              nativeInputProps: {
+                checked: activeView === 'graphique',
+                onChange: () => setActiveView('graphique'),
+              },
+            },
+            {
+              label: 'Tableau',
+              nativeInputProps: {
+                checked: activeView === 'tableau',
+                onChange: () => setActiveView('tableau'),
+              },
+            },
+          ]}
+        />
+        <Button
+          iconId="fr-icon-download-line"
+          onClick={handleExportCsv}
+          disabled={!perYearData || perYearData.length === 0}
+          type="button"
+        >
+          Exporter
+        </Button>
+      </div>
+
+      {/* Content */}
+      {loadingPerYear ? (
+        <div className="flex items-center gap-2 fr-py-3w">
+          <Loader type="dots" size="sm" />
+        </div>
+      ) : !perYearData || perYearData.length === 0 ? (
+        <p
+          className="fr-text--sm fr-mb-0"
+          style={{ color: fr.colors.decisions.text.mention.grey.default }}
+        >
+          Aucune donnée disponible pour cette période.
+        </p>
+      ) : activeView === 'graphique' ? (
+        chartItems && (
+          <VerticalChartBar
+            chartItems={chartItems}
+            yAxisLabel="Nombre d'analyses"
+            unit="analyse(s)"
+            chartHeight={350}
+          />
+        )
+      ) : (
+        <Table
+          headers={['Année', 'Conformes', 'En dépassement', 'Total']}
+          fixed
+          className="w-full"
+          data={perYearData.map((d) => [
+            d.annee,
+            d.sans_dep.toLocaleString('fr-FR'),
+            d.avec_dep > 0 ? (
+              <span style={{ color: fr.colors.decisions.text.default.error.default }}>
+                {d.avec_dep.toLocaleString('fr-FR')}
+              </span>
+            ) : (
+              d.avec_dep.toLocaleString('fr-FR')
+            ),
+            d.total.toLocaleString('fr-FR'),
+          ])}
+        />
+      )}
+    </SectionCard>
+  )
+}

--- a/inertia/components/captage/substance-detail.tsx
+++ b/inertia/components/captage/substance-detail.tsx
@@ -1,147 +1,180 @@
+import { useState } from 'react'
 import { fr } from '@codegouvfr/react-dsfr'
+import Button from '@codegouvfr/react-dsfr/Button'
 import ResumeCard from '~/ui/ResumeCard'
+import Loader from '~/ui/Loader'
+import Divider from '~/ui/Divider'
 import type { ChroniqueData } from '#types/captage'
 import { formatUnite, SubstanceScatterChart } from './substance-scatter-chart'
+import LabelInfo from '~/ui/LabelInfo'
 
-export function SubstanceDetail({ chronique }: { chronique: ChroniqueData }) {
-  const unite = formatUnite(chronique.info.code_unite)
+type Props = {
+  chronique: ChroniqueData | null
+  loading?: boolean
+  headerContent?: React.ReactNode
+}
+
+export function SubstanceDetail({ chronique, loading, headerContent }: Props) {
+  const unite = chronique ? formatUnite(chronique.info.code_unite) : ''
+  const [leftOpen, setLeftOpen] = useState(true)
 
   return (
-    <div className="grid grid-cols-2 gap-4" style={{ alignItems: 'start' }}>
-      {/* Left: Informations générales */}
+    <div
+      className="grid w-full overflow-hidden"
+      style={{
+        border: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
+        gridTemplateColumns: leftOpen ? '260px 1fr' : '0px 1fr',
+        transition: 'grid-template-columns 0.2s ease',
+      }}
+    >
+      {/* Left Sidebar: Informations générales */}
       <div
-        className="flex flex-col gap-3 fr-p-3w"
+        className="overflow-hidden"
         style={{
-          border: `1px solid ${fr.colors.decisions.border.default.grey.default}`,
+          borderRight: leftOpen
+            ? `1px solid ${fr.colors.decisions.border.default.grey.default}`
+            : 'none',
         }}
       >
-        <h6 className="fr-text--md fr-mb-0" style={{ fontWeight: 700 }}>
-          <span className="fr-icon-list-unordered fr-icon--sm fr-mr-1v" aria-hidden="true" />
-          Informations générales
-        </h6>
+        <div style={{ width: 260 }}>
+          <div
+            className="flex items-center fr-pl-2v h-16"
+            style={{ background: fr.colors.decisions.background.alt.blueFrance.default }}
+          >
+            <h6 className="fr-text--md font-medium fr-m-0 w-full fr-pr-2v">
+              Informations générales
+            </h6>
+            <Button
+              iconId="fr-icon-arrow-left-s-line"
+              priority="tertiary no outline"
+              onClick={() => setLeftOpen(false)}
+              title="Fermer le panneau"
+            />
+          </div>
 
-        <div className="flex flex-col gap-1">
-          <p className="fr-text--sm fr-mb-0">
-            <span style={{ color: fr.colors.decisions.text.mention.grey.default }}>
-              Code SANDRE :{' '}
-            </span>
-            <strong>{chronique.info.code_parametre}</strong>
-          </p>
-          {unite && (
-            <p className="fr-text--sm fr-mb-0">
-              <span style={{ color: fr.colors.decisions.text.mention.grey.default }}>Unité : </span>
-              <strong>{unite}</strong>
-            </p>
+          {chronique && (
+            <div className="flex flex-col gap-3 fr-p-2w">
+              <div className="flex flex-col gap-1">
+                <LabelInfo label="Code SANDRE" info={chronique.info.code_parametre} />
+                {unite && <LabelInfo label="Unité" info={unite} />}
+              </div>
+
+              {(chronique.info.seuil_regl !== null || chronique.info.seuil_alerte !== null) && (
+                <div className="flex flex-col gap-3">
+                  <Divider label=" Seuils" />
+                  <div className="flex flex-col gap-1">
+                    {chronique.info.seuil_regl !== null && (
+                      <LabelInfo
+                        label="Seuil réglementaire"
+                        info={`${chronique.info.seuil_regl} ${unite}`}
+                      />
+                    )}
+                    {chronique.info.seuil_alerte !== null && (
+                      <LabelInfo
+                        label="Seuil d'alerte"
+                        info={`${chronique.info.seuil_alerte} ${unite}`}
+                      />
+                    )}
+                  </div>
+                </div>
+              )}
+              <ResumeCard
+                size="sm"
+                title="Dépassement réglementaire"
+                value={`${chronique.stats.frequence_dep_regl.toLocaleString('fr-FR')}%`}
+                iconId="fr-icon-warning-line"
+                color={
+                  chronique.stats.nb_dep_regl > 0
+                    ? fr.colors.decisions.text.default.error.default
+                    : fr.colors.decisions.text.default.grey.default
+                }
+              />
+            </div>
           )}
         </div>
+      </div>
 
-        {(chronique.info.seuil_regl !== null || chronique.info.seuil_alerte !== null) && (
-          <div className="flex flex-col gap-1">
-            <hr className="fr-hr fr-mt-1w fr-mb-1w" />
-            <p
-              className="fr-text--md fr-mb-1v"
-              style={{
-                fontWeight: 700,
-                color: fr.colors.decisions.text.mention.grey.default,
-              }}
-            >
-              Seuils
-            </p>
-            {chronique.info.seuil_regl !== null && (
-              <p className="fr-text--sm fr-mb-0">
-                <span style={{ color: fr.colors.decisions.text.mention.grey.default }}>
-                  Seuil réglementaire :{' '}
-                </span>
-                <strong>
-                  {chronique.info.seuil_regl} {unite}
-                </strong>
-              </p>
-            )}
-            {chronique.info.seuil_alerte !== null && (
-              <p className="fr-text--sm fr-mb-0">
-                <span style={{ color: fr.colors.decisions.text.mention.grey.default }}>
-                  Seuil d'alerte :{' '}
-                </span>
-                <strong>
-                  {chronique.info.seuil_alerte} {unite}
-                </strong>
+      {/* Center: Header + Content */}
+      <div className="min-w-0 overflow-hidden">
+        {/* Header */}
+        <div
+          className="flex items-center fr-p-2v h-16"
+          style={{ background: fr.colors.decisions.background.alt.blueFrance.default }}
+        >
+          {!leftOpen && (
+            <Button
+              iconId="fr-icon-arrow-right-s-line"
+              priority="tertiary no outline"
+              onClick={() => setLeftOpen(true)}
+              title="Ouvrir le panneau gauche"
+            />
+          )}
+          <div className="flex flex-1 fr-px-2v justify-end">{headerContent}</div>
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div className="flex items-center gap-2 fr-py-2w fr-px-2w">
+            <Loader type="dots" size="sm" />
+          </div>
+        ) : chronique ? (
+          <div className="flex flex-col gap-3 fr-p-2w">
+            <h6 className="fr-text--md fr-mb-0" style={{ fontWeight: 700 }}>
+              <span className="fr-icon-microscope-line fr-icon--sm fr-mr-1v" aria-hidden="true" />
+              Résultat des prélèvements sur la période
+            </h6>
+
+            <div className="grid grid-cols-2 gap-2">
+              <ResumeCard
+                size="sm"
+                title="Moyenne de concentration"
+                value={`${chronique.stats.moyenne.toLocaleString('fr-FR')} ${unite}`}
+                iconId="fr-icon-line-chart-line"
+                color={fr.colors.decisions.text.label.blueFrance.default}
+              />
+              <ResumeCard
+                size="sm"
+                title="Maximum des concentrations observés"
+                value={`${chronique.stats.maximum.toLocaleString('fr-FR')} ${unite}`}
+                iconId="fr-icon-warning-line"
+                color={fr.colors.decisions.text.default.warning.default}
+              />
+              <ResumeCard
+                size="sm"
+                title="Résultats en dépassement"
+                value={chronique.stats.nb_dep_regl.toLocaleString('fr-FR')}
+                iconId="fr-icon-error-line"
+                color={
+                  chronique.stats.nb_dep_regl > 0
+                    ? fr.colors.decisions.text.default.error.default
+                    : fr.colors.decisions.text.default.grey.default
+                }
+              />
+              <ResumeCard
+                size="sm"
+                title="Fréquence de dépassement"
+                value={`${chronique.stats.frequence_dep_regl.toLocaleString('fr-FR')}%`}
+                iconId="fr-icon-error-line"
+                color={
+                  chronique.stats.frequence_dep_regl > 0
+                    ? fr.colors.decisions.text.default.error.default
+                    : fr.colors.decisions.text.default.grey.default
+                }
+              />
+            </div>
+
+            {chronique.series.length > 0 ? (
+              <SubstanceScatterChart data={chronique} />
+            ) : (
+              <p
+                className="fr-text--sm fr-mb-0"
+                style={{ color: fr.colors.decisions.text.mention.grey.default }}
+              >
+                Aucune mesure disponible pour cette période.
               </p>
             )}
           </div>
-        )}
-
-        <ResumeCard
-          size="sm"
-          title="Dépassement réglementaire"
-          value={`${chronique.stats.frequence_dep_regl.toLocaleString('fr-FR')}%`}
-          iconId="fr-icon-warning-line"
-          color={
-            chronique.stats.nb_dep_regl > 0
-              ? fr.colors.decisions.text.default.error.default
-              : fr.colors.decisions.text.default.grey.default
-          }
-        />
-      </div>
-
-      {/* Right: Résultats + chart */}
-      <div
-        className="flex flex-col gap-3 fr-p-2w"
-        style={{ border: `1px solid ${fr.colors.decisions.border.default.grey.default}` }}
-      >
-        <h6 className="fr-text--md fr-mb-0" style={{ fontWeight: 700 }}>
-          <span className="fr-icon-microscope-line fr-icon--sm fr-mr-1v" aria-hidden="true" />
-          Résultat des prélèvements sur la période
-        </h6>
-
-        <div className="grid grid-cols-2 gap-2">
-          <ResumeCard
-            size="sm"
-            title="Moyenne de concentration"
-            value={`${chronique.stats.moyenne.toLocaleString('fr-FR')} ${unite}`}
-            iconId="fr-icon-line-chart-line"
-            color={fr.colors.decisions.text.label.blueFrance.default}
-          />
-          <ResumeCard
-            size="sm"
-            title="Maximum des concentrations observés"
-            value={`${chronique.stats.maximum.toLocaleString('fr-FR')} ${unite}`}
-            iconId="fr-icon-warning-line"
-            color={fr.colors.decisions.text.default.warning.default}
-          />
-          <ResumeCard
-            size="sm"
-            title="Résultats en dépassement"
-            value={chronique.stats.nb_dep_regl.toLocaleString('fr-FR')}
-            iconId="fr-icon-error-line"
-            color={
-              chronique.stats.nb_dep_regl > 0
-                ? fr.colors.decisions.text.default.error.default
-                : fr.colors.decisions.text.default.grey.default
-            }
-          />
-          <ResumeCard
-            size="sm"
-            title="Fréquence de dépassement"
-            value={`${chronique.stats.frequence_dep_regl.toLocaleString('fr-FR')}%`}
-            iconId="fr-icon-error-line"
-            color={
-              chronique.stats.frequence_dep_regl > 0
-                ? fr.colors.decisions.text.default.error.default
-                : fr.colors.decisions.text.default.grey.default
-            }
-          />
-        </div>
-
-        {chronique.series.length > 0 ? (
-          <SubstanceScatterChart data={chronique} />
-        ) : (
-          <p
-            className="fr-text--sm fr-mb-0"
-            style={{ color: fr.colors.decisions.text.mention.grey.default }}
-          >
-            Aucune mesure disponible pour cette période.
-          </p>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/inertia/components/captage/substance-detail.tsx
+++ b/inertia/components/captage/substance-detail.tsx
@@ -36,62 +36,64 @@ export function SubstanceDetail({ chronique, loading, headerContent }: Props) {
             : 'none',
         }}
       >
-        <div style={{ width: 260 }}>
-          <div
-            className="flex items-center fr-pl-2v h-16"
-            style={{ background: fr.colors.decisions.background.alt.blueFrance.default }}
-          >
-            <h6 className="fr-text--md font-medium fr-m-0 w-full fr-pr-2v">
-              Informations générales
-            </h6>
-            <Button
-              iconId="fr-icon-arrow-left-s-line"
-              priority="tertiary no outline"
-              onClick={() => setLeftOpen(false)}
-              title="Fermer le panneau"
-            />
-          </div>
-
-          {chronique && (
-            <div className="flex flex-col gap-3 fr-p-2w">
-              <div className="flex flex-col gap-1">
-                <LabelInfo label="Code SANDRE" info={chronique.info.code_parametre} />
-                {unite && <LabelInfo label="Unité" info={unite} />}
-              </div>
-
-              {(chronique.info.seuil_regl !== null || chronique.info.seuil_alerte !== null) && (
-                <div className="flex flex-col gap-3">
-                  <Divider label=" Seuils" />
-                  <div className="flex flex-col gap-1">
-                    {chronique.info.seuil_regl !== null && (
-                      <LabelInfo
-                        label="Seuil réglementaire"
-                        info={`${chronique.info.seuil_regl} ${unite}`}
-                      />
-                    )}
-                    {chronique.info.seuil_alerte !== null && (
-                      <LabelInfo
-                        label="Seuil d'alerte"
-                        info={`${chronique.info.seuil_alerte} ${unite}`}
-                      />
-                    )}
-                  </div>
-                </div>
-              )}
-              <ResumeCard
-                size="sm"
-                title="Dépassement réglementaire"
-                value={`${chronique.stats.frequence_dep_regl.toLocaleString('fr-FR')}%`}
-                iconId="fr-icon-warning-line"
-                color={
-                  chronique.stats.nb_dep_regl > 0
-                    ? fr.colors.decisions.text.default.error.default
-                    : fr.colors.decisions.text.default.grey.default
-                }
+        {leftOpen && (
+          <div style={{ width: 260 }}>
+            <div
+              className="flex items-center fr-pl-2v h-16"
+              style={{ background: fr.colors.decisions.background.alt.blueFrance.default }}
+            >
+              <h6 className="fr-text--md font-medium fr-m-0 w-full fr-pr-2v">
+                Informations générales
+              </h6>
+              <Button
+                iconId="fr-icon-arrow-left-s-line"
+                priority="tertiary no outline"
+                onClick={() => setLeftOpen(false)}
+                title="Fermer le panneau"
               />
             </div>
-          )}
-        </div>
+
+            {chronique && (
+              <div className="flex flex-col gap-3 fr-p-2w">
+                <div className="flex flex-col gap-1">
+                  <LabelInfo label="Code SANDRE" info={chronique.info.code_parametre} />
+                  {unite && <LabelInfo label="Unité" info={unite} />}
+                </div>
+
+                {(chronique.info.seuil_regl !== null || chronique.info.seuil_alerte !== null) && (
+                  <div className="flex flex-col gap-3">
+                    <Divider label=" Seuils" />
+                    <div className="flex flex-col gap-1">
+                      {chronique.info.seuil_regl !== null && (
+                        <LabelInfo
+                          label="Seuil réglementaire"
+                          info={`${chronique.info.seuil_regl} ${unite}`}
+                        />
+                      )}
+                      {chronique.info.seuil_alerte !== null && (
+                        <LabelInfo
+                          label="Seuil d'alerte"
+                          info={`${chronique.info.seuil_alerte} ${unite}`}
+                        />
+                      )}
+                    </div>
+                  </div>
+                )}
+                <ResumeCard
+                  size="sm"
+                  title="Dépassement réglementaire"
+                  value={`${chronique.stats.frequence_dep_regl.toLocaleString('fr-FR')}%`}
+                  iconId="fr-icon-warning-line"
+                  color={
+                    chronique.stats.nb_dep_regl > 0
+                      ? fr.colors.decisions.text.default.error.default
+                      : fr.colors.decisions.text.default.grey.default
+                  }
+                />
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Center: Header + Content */}

--- a/inertia/ui/SectionCard/index.tsx
+++ b/inertia/ui/SectionCard/index.tsx
@@ -6,6 +6,7 @@ import TruncatedText from '../TruncatedText'
 
 export type SectionCardProps = {
   title?: string
+  caption?: string
   children: ReactNode
   icon?: string
   size?: 'small' | 'medium'
@@ -18,6 +19,7 @@ export type SectionCardProps = {
 
 export default function SectionCard({
   title,
+  caption,
   children,
   icon,
   size = 'medium',
@@ -30,7 +32,7 @@ export default function SectionCard({
   const hasHeader = !!(title || icon || (handleAction && actionIcon))
   return (
     <section
-      className={`flex flex-col fr-p-2w${hasHeader ? ' gap-2' : ''}`}
+      className={`flex flex-col fr-p-2w${hasHeader ? ' gap-6' : ''}`}
       style={{
         border: `1px solid ${background === 'primary' ? fr.colors.decisions.border.default.grey.default : 'transparent'}`,
         backgroundColor:
@@ -43,35 +45,70 @@ export default function SectionCard({
         <div className="flex items-center">
           <div className="flex-1 min-w-0">
             {size === 'small' ? (
-              <div className="flex gap-1">
-                {icon && <span className={`${icon} fr-icon-md fr-mb-2w`} aria-hidden="true"></span>}
-                {title && (
-                  <TruncatedText
-                    maxLines={1}
-                    className="fr-mb-0"
-                    hideTooltip={hideLongTitleTooltip}
-                    as="h6"
-                  >
-                    {title}
-                  </TruncatedText>
+              <div className={`flex gap-1 ${caption ? 'items-start' : 'items-center'}`}>
+                {icon && (
+                  <span
+                    className={`${icon} fr-icon-md ${caption ? 'fr-mb-2w' : 'fr-mb-0'}`}
+                    style={{ color: fr.colors.decisions.text.title.blueFrance.default }}
+                    aria-hidden="true"
+                  ></span>
                 )}
+
+                <div className="flex flex-col">
+                  {title && (
+                    <TruncatedText
+                      maxLines={1}
+                      className="fr-mb-0"
+                      hideTooltip={hideLongTitleTooltip}
+                      as="h6"
+                    >
+                      {title}
+                    </TruncatedText>
+                  )}
+                  {caption && (
+                    <span
+                      className="fr-text--sm fr-mb-0"
+                      style={{ color: fr.colors.decisions.text.mention.grey.default }}
+                    >
+                      {caption}
+                    </span>
+                  )}
+                </div>
               </div>
             ) : (
-              <div className="flex gap-1">
-                {icon && <span className={`${icon} fr-mb-2w`} aria-hidden="true"></span>}
-                {title && (
-                  <TruncatedText
-                    maxLines={2}
-                    className="fr-mb-0 fr-mb-2w"
-                    hideTooltip={hideLongTitleTooltip}
-                    as="h4"
-                  >
-                    {title}
-                  </TruncatedText>
+              <div className={`flex gap-1 ${caption ? 'items-start' : 'items-center'}`}>
+                {icon && (
+                  <span
+                    className={`${icon} ${caption ? 'fr-mb-2w' : 'fr-mb-0'}`}
+                    style={{ color: fr.colors.decisions.text.title.blueFrance.default }}
+                    aria-hidden="true"
+                  ></span>
                 )}
+
+                <div className="flex flex-col">
+                  {title && (
+                    <TruncatedText
+                      maxLines={2}
+                      className="fr-mb-0"
+                      hideTooltip={hideLongTitleTooltip}
+                      as="h4"
+                    >
+                      {title}
+                    </TruncatedText>
+                  )}
+                  {caption && (
+                    <span
+                      className="fr-mb-0"
+                      style={{ color: fr.colors.decisions.text.mention.grey.default }}
+                    >
+                      {caption}
+                    </span>
+                  )}
+                </div>
               </div>
             )}
           </div>
+
           {handleAction &&
             actionIcon &&
             (size === 'small' ? (

--- a/inertia/ui/SectionCard/section-card.stories.tsx
+++ b/inertia/ui/SectionCard/section-card.stories.tsx
@@ -9,6 +9,10 @@ const meta = {
       control: 'text',
       description: 'Titre affiché dans l’en-tête de la section.',
     },
+    caption: {
+      control: 'text',
+      description: 'Texte d’accompagnement affiché sous le titre.',
+    },
     icon: {
       control: 'text',
       description: 'Nom de l’icône FR à afficher à gauche du titre (ex: "map-pin-2-line").',
@@ -48,6 +52,7 @@ const meta = {
   },
   args: {
     title: 'Titre de la section',
+    caption: 'Ceci est une description de la section pour donner plus de contexte à l’utilisateur.',
     icon: 'fr-icon-map-pin-2-line',
     actionIcon: 'fr-icon-edit-line',
     actionLabel: 'Modifier',
@@ -80,6 +85,18 @@ export const SansAction = {
   args: {
     actionIcon: null,
     handleAction: null,
+  },
+}
+
+export const PetiteTaille = {
+  args: {
+    size: 'small',
+  },
+}
+
+export const SansSousTitre = {
+  args: {
+    caption: null,
   },
 }
 

--- a/inertia/ui/SingleSelectMenu/index.tsx
+++ b/inertia/ui/SingleSelectMenu/index.tsx
@@ -109,6 +109,9 @@ export default function SingleSelectMenu<T extends string | number>({
               color: selectedOption
                 ? fr.colors.decisions.text.default.grey.default
                 : fr.colors.decisions.text.mention.grey.default,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
             }}
           >
             {selectedOption ? selectedOption.label : placeholder}


### PR DESCRIPTION
Cette pull request refactorise et améliore l’interface utilisateur ainsi que la structure du code de la section des analyses d’eau (« captage analyses »). Les principales évolutions incluent l’extraction et la modularisation de la logique « Qualité Suivi » dans un composant dédié, l’amélioration de la vue détaillée des substances avec une barre latérale repliable et l’injection de contenu dans l’en-tête, ainsi que la mise à jour du sélecteur de substances pour utiliser une liste déroulante personnalisée. Ces changements améliorent la maintenabilité, la clarté du code et l’expérience utilisateur.

## Extraction de composants et refactorisation de l’interface

* Extraction de la section « Qualité Suivi » depuis `captage-analyses-header.tsx` vers un nouveau composant `qualite-suivi.tsx`, encapsulant la logique de bascule entre vue graphique/tableau, l’export CSV et les états de chargement. Cela améliore la séparation des responsabilités et la lisibilité du code.
* Refactorisation du composant principal d’en-tête des analyses afin de déléguer l’affichage des données annuelles au nouveau composant `QualiteSuivi`, simplifiant ainsi le composant parent.

## Améliorations des détails et de la sélection des substances

* Amélioration du composant `SubstanceDetail` avec :
  * une barre latérale repliable pour les informations générales ;
  * un emplacement d’en-tête permettant d’injecter du contenu personnalisé (comme le sélecteur de substances) ;
  * une meilleure gestion des états de chargement.
* Mise à jour de la vue « chroniques par substances » afin d’utiliser un menu déroulant personnalisé `SingleSelectMenu` pour la sélection des substances, remplaçant le composant `Select` de DSFR pour offrir davantage de flexibilité et une meilleure cohérence de l’interface.

Ces changements rendent globalement la base de code plus modulaire et l’interface plus ergonomique.


https://github.com/user-attachments/assets/d8a0c33e-3bfb-4cc2-84ce-de7040c60bba

