### PR TITLE
Ajout de commandes de seeding d'utilisateurs et territoires

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,7 @@ npm run storybook
 ```
 
 Cela lancera Storybook sur `http://localhost:6006`.
+
+# Documentation
+
+La documentation de l'application se trouve dans le dossier `doc` et est écrite en Markdown.

--- a/app/services/user_service.ts
+++ b/app/services/user_service.ts
@@ -1,0 +1,78 @@
+import User from '#models/user'
+import Territoire from '#models/territoire'
+import Env from '#start/env'
+
+export type EnvUserSeeds = Array<{
+  email: string
+  fullName?: string
+  password?: string
+  // AAC Codes
+  territoireCodes?: string[]
+  // Territoire UUIDs
+  territoireIds?: string[]
+}>
+
+export default class UserService {
+  async seedUsersFromEnv(
+    extraUsers: Array<{ fullName: string; email: string; password?: string }> = []
+  ) {
+    const usersToInject: EnvUserSeeds = JSON.parse(Env.get('USERS_TO_SEED') || '[]')
+
+    const normalized = usersToInject.map((user) => ({
+      fullName: user.fullName,
+      email: user.email.toLowerCase(),
+      password: user.password,
+    }))
+
+    await User.updateOrCreateMany('email', [...extraUsers, ...normalized])
+  }
+
+  // This seeder assigns territoires to users based on the USERS_TO_SEED environment variable.
+  // The variable must respect the EnvUserSeeds type.
+  // territoireCodes is useful for AACs from the SANDRE national referential, while territoireIds can be used for any existing territoires.
+  // If both territoireCodes and territoireIds are present, both are read.
+  async assignTerritoiresFromEnv() {
+    const usersToSeed: EnvUserSeeds = JSON.parse(Env.get('USERS_TO_SEED') || '[]')
+
+    for (const userData of usersToSeed) {
+      const email = userData.email.toLowerCase().trim()
+
+      const user = await User.findBy('email', email)
+      if (!user) {
+        console.warn(`User "${email}" not found, skipping territoire assignment`)
+        continue
+      }
+
+      const territoiresIdsToSync = new Set<string>()
+
+      if (userData.territoireCodes && userData.territoireCodes.length > 0) {
+        const territoires = await Territoire.query().whereIn('code', userData.territoireCodes)
+        const notFound = userData.territoireCodes.filter(
+          (c) => !territoires.some((t) => t.code === c)
+        )
+        if (notFound.length > 0) {
+          console.warn(`Territoire codes not found: ${notFound.join(', ')}`)
+        }
+        for (const territoire of territoires) {
+          territoiresIdsToSync.add(territoire.id)
+        }
+      }
+
+      if (userData.territoireIds && userData.territoireIds.length > 0) {
+        const territoires = await Territoire.query().whereIn('id', userData.territoireIds)
+        const notFound = userData.territoireIds.filter((c) => !territoires.some((t) => t.id === c))
+        if (notFound.length > 0) {
+          console.warn(`Territoire ids not found: ${notFound.join(', ')}`)
+        }
+        for (const territoire of territoires) {
+          territoiresIdsToSync.add(territoire.id)
+        }
+      }
+
+      await user.related('territoires').sync(territoiresIdsToSync.values().toArray(), false)
+      console.info(
+        `Assigned ${territoiresIdsToSync.size} territoire(s) to "${email}" based on their ids.`
+      )
+    }
+  }
+}

--- a/commands/user_assign_territoires.ts
+++ b/commands/user_assign_territoires.ts
@@ -1,0 +1,22 @@
+import { BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import UserService from '#services/user_service'
+
+export default class UserAssignTerritoires extends BaseCommand {
+  static commandName = 'user:assign-territoires'
+  static description = 'Assign territoires to users from the USERS_TO_SEED environment variable'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  async run() {
+    try {
+      await new UserService().assignTerritoiresFromEnv()
+      this.logger.success('Territoires assigned successfully')
+    } catch (error) {
+      this.logger.error(error instanceof Error ? error.message : 'Failed to assign territoires')
+      this.exitCode = 1
+    }
+  }
+}

--- a/commands/user_seed.ts
+++ b/commands/user_seed.ts
@@ -1,0 +1,22 @@
+import { BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import UserService from '#services/user_service'
+
+export default class UserSeed extends BaseCommand {
+  static commandName = 'user:seed'
+  static description = 'Create or update users from the USERS_TO_SEED environment variable'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  async run() {
+    try {
+      await new UserService().seedUsersFromEnv()
+      this.logger.success('Users seeded successfully')
+    } catch (error) {
+      this.logger.error(error instanceof Error ? error.message : 'Failed to seed users')
+      this.exitCode = 1
+    }
+  }
+}

--- a/database/seeders/1_user_seeder.ts
+++ b/database/seeders/1_user_seeder.ts
@@ -1,30 +1,15 @@
 import { BaseSeeder } from '@adonisjs/lucid/seeders'
-import User from '#models/user'
-import Env from '#start/env'
+import UserService from '#services/user_service'
 
 export default class extends BaseSeeder {
   async run() {
-    const usersToInject: Array<{
-      fullName: string
-      email: string
-      password: string
-      territoireCodes?: string[]
-    }> = JSON.parse(Env.get('USERS_TO_SEED') || '[]')
-
-    for (const user of usersToInject) {
-      user.email = user.email.toLowerCase()
-      delete user.territoireCodes
-    }
-
-    await User.updateOrCreateMany(
-      'email',
-      [
-        {
-          fullName: 'Jeanne Martin',
-          email: process.env.ADMIN_EMAIL,
-          password: process.env.ADMIN_PASSWORD,
-        },
-      ].concat(usersToInject)
-    )
+    const userService = new UserService()
+    await userService.seedUsersFromEnv([
+      {
+        fullName: 'Jeanne Martin',
+        email: process.env.ADMIN_EMAIL!,
+        password: process.env.ADMIN_PASSWORD,
+      },
+    ])
   }
 }

--- a/database/seeders/8_assign_territoire_seeder.ts
+++ b/database/seeders/8_assign_territoire_seeder.ts
@@ -1,67 +1,9 @@
 import { BaseSeeder } from '@adonisjs/lucid/seeders'
-import User from '#models/user'
-import Territoire from '#models/territoire'
-import Env from '#start/env'
-
-// This seeder assigns territoires to users based on the USERS_TO_SEED environment variable.
-// The variable must respect the EnvUserSeeds type.
-// territoireCodes is useful for AACs from the SANDRE national referential, while territoireIds can be used for any existing territoires.
-// If both territoireCodes and territoireIds are present, both are read.
-
-type EnvUserSeeds = Array<{
-  email: string
-  // AAC Codes
-  territoireCodes?: string[]
-  // Territoire UUIDs
-  territoireIds?: string[]
-}>
+import UserService from '#services/user_service'
 
 export default class extends BaseSeeder {
   async run() {
-    // Read the environment to find territoires
-    const usersToSeed: EnvUserSeeds = JSON.parse(Env.get('USERS_TO_SEED') || '[]')
-
-    for (const userData of usersToSeed) {
-      userData.email = userData.email.toLowerCase().trim()
-
-      const user = await User.findBy('email', userData.email)
-      if (!user) {
-        console.warn(`User "${userData.email}" not found, skipping territoire assignment`)
-        continue
-      }
-
-      const territoiresIdsToSync = new Set<string>()
-
-      if (userData.territoireCodes && userData.territoireCodes.length > 0) {
-        const territoires = await Territoire.query().whereIn('code', userData.territoireCodes)
-        const notFound = userData.territoireCodes.filter(
-          (c) => !territoires.some((t) => t.code === c)
-        )
-        if (notFound.length > 0) {
-          console.warn(`Territoire codes not found: ${notFound.join(', ')}`)
-        }
-
-        for (const territoire of territoires) {
-          territoiresIdsToSync.add(territoire.id)
-        }
-      }
-      if (userData.territoireIds && userData.territoireIds.length > 0) {
-        const territoires = await Territoire.query().whereIn('id', userData.territoireIds)
-        const notFound = userData.territoireIds.filter((c) => !territoires.some((t) => t.id === c))
-        if (notFound.length > 0) {
-          console.warn(`Territoire ids not found: ${notFound.join(', ')}`)
-        }
-
-        for (const territoire of territoires) {
-          territoiresIdsToSync.add(territoire.id)
-        }
-      }
-
-      // The sync method ensures the relations are up to date with the env var value
-      await user.related('territoires').sync(territoiresIdsToSync.values().toArray(), false)
-      console.info(
-        `Assigned ${territoiresIdsToSync.size} territoire(s) to "${userData.email}" based on their ids.`
-      )
-    }
+    const userService = new UserService()
+    await userService.assignTerritoiresFromEnv()
   }
 }

--- a/doc/commandes.md
+++ b/doc/commandes.md
@@ -1,0 +1,53 @@
+# Commandes CLI
+
+Toutes les commandes se lancent avec `node ace <commande>`.
+
+---
+
+## `user:seed`
+
+Crée ou met à jour les utilisateurs définis dans la variable d'environnement `USERS_TO_SEED`.
+
+```bash
+node ace user:seed
+```
+
+La variable `USERS_TO_SEED` doit contenir un tableau JSON :
+
+```json
+[{ "email": "foo@bar.com", "fullName": "Foo Bar", "password": "secret" }]
+```
+
+---
+
+## `user:assign-territoires`
+
+Assigne les territoires aux utilisateurs définis dans `USERS_TO_SEED`, en se basant sur les champs `territoireCodes` (codes SANDRE) et/ou `territoireIds` (UUIDs).
+
+```bash
+node ace user:assign-territoires
+```
+
+```json
+[{ "email": "foo@bar.com", "territoireCodes": ["AAC001"], "territoireIds": ["uuid-..."] }]
+```
+
+---
+
+## `territoire:create`
+
+Crée un nouveau territoire avec le nom donné.
+
+```bash
+node ace territoire:create "Nom du territoire"
+```
+
+---
+
+## `territoire:assign`
+
+Assigne un territoire existant à un utilisateur existant (par leurs UUIDs).
+
+```bash
+node ace territoire:assign <userId> <territoireId>
+```

--- a/doc/scripts.md
+++ b/doc/scripts.md
@@ -1,0 +1,13 @@
+# Scripts
+
+Les scripts du dossier `scripts` ne sont pas liés à AdonisJs et ne sont pas empaquetés dans l'application finale.
+Ce sont des utilitaires NodeJs pour la maintenance et l'opération du projet.
+
+## `flatten_json.js`
+
+Lit un fichier JSON et génère une version sans espaces ni retours à la ligne, suffixée `_flattened.json`. Utile pour copier une valeur dans une variable d'environnement.
+
+```bash
+node flatten_json.js USERS_TO_SEED_1.json
+# → génère USERS_TO_SEED_1_flattened.json
+```

--- a/scripts/flatten_json.js
+++ b/scripts/flatten_json.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { resolve, basename, dirname } from 'node:path'
+
+const input = process.argv[2]
+
+if (!input) {
+  console.error('Usage: node flatten_json.js <file.json>')
+  process.exit(1)
+}
+
+const inputPath = resolve(input)
+const content = JSON.parse(readFileSync(inputPath, 'utf-8'))
+const flattened = JSON.stringify(content)
+
+const name = basename(inputPath, '.json')
+const outputPath = resolve(dirname(inputPath), `${name}_flattened.json`)
+
+writeFileSync(outputPath, flattened, 'utf-8')
+console.log(`Written to ${outputPath}`)


### PR DESCRIPTION
Cette PR ajoute quelques commandes pour seed des utilisateurs ou des relations utilisateur-territoires. Ainsi on peut ajouter des utilisateurs en lots sans lancer tous les seeders en même temps.

Un script utilitaire "flatten_json" permet de transformer des fichiers json en valeur "stringifiée" pour l'insertion en variable d'environnement.

Un dossier "doc" regroupe la documentation du projet. Les commandes CLI existantes sont documentées.