### PR TITLE
Ajout de l'attachement des exploitations/parcelles/captages aux projets

### DIFF
--- a/app/controllers/projects_controller.ts
+++ b/app/controllers/projects_controller.ts
@@ -1,7 +1,10 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
 import Project from '#models/project'
+import Parcelle from '#models/parcelle'
+import Captage from '#models/captage'
 import { ProjectService } from '#services/project_service'
+import { ExploitationService } from '#services/exploitation_service'
 import {
   createProjectValidator,
   destroyProjectValidator,
@@ -9,10 +12,14 @@ import {
   updateProjectValidator,
 } from '#validators/project'
 import { ProjectDto } from '../dto/project_dto.js'
+import { createErrorFlashMessage } from '../helpers/flash_message.js'
 
 @inject()
 export default class ProjectsController {
-  constructor(public projectService: ProjectService) {}
+  constructor(
+    public projectService: ProjectService,
+    public exploitationService: ExploitationService
+  ) {}
 
   async index({ auth, response }: HttpContext) {
     const user = auth.getUserOrFail()
@@ -33,9 +40,60 @@ export default class ProjectsController {
     })
   }
 
-  async store({ auth, request, response }: HttpContext) {
+  async store({ auth, request, response, session }: HttpContext) {
     const user = auth.getUserOrFail()
     const payload = await request.validateUsing(createProjectValidator)
+
+    // We check if the user has authorization to attach these exploitations (same AAC)
+    if (payload.exploitationIds?.length) {
+      const found = await this.exploitationService
+        .queryActiveExploitations(user.id)
+        .whereIn('id', payload.exploitationIds)
+        .count('* as total')
+        .first()
+
+      if (Number(found?.$extras.total) !== payload.exploitationIds.length) {
+        createErrorFlashMessage(
+          session,
+          "Certaines exploitations désignées n'existent pas ou ne vous appartiennent pas."
+        )
+        return response.redirect().back()
+      }
+    }
+
+    if (payload.parcelleIds?.length) {
+      const found = await Parcelle.query()
+        .whereIn('id', payload.parcelleIds)
+        .whereNull('exploitation_id')
+        .orWhereHas('exploitation', (exploitationQuery) => {
+          exploitationQuery.whereHas('territoires', (territoireQuery) => {
+            territoireQuery.whereHas('users', (userQuery) => {
+              userQuery.where('users.id', user.id)
+            })
+          })
+        })
+        .count('* as total')
+        .first()
+      if (Number(found?.$extras.total) !== payload.parcelleIds.length) {
+        createErrorFlashMessage(
+          session,
+          "Certaines parcelles désignées n'existent pas ou appartiennent à des exploitations auxquelles vous n'avez pas accès."
+        )
+        return response.redirect().back()
+      }
+    }
+
+    if (payload.captageIds?.length) {
+      const found = await Captage.query()
+        .whereIn('id', payload.captageIds)
+        .count('* as total')
+        .first()
+      if (Number(found?.$extras.total) !== payload.captageIds.length) {
+        createErrorFlashMessage(session, "Certains captages désignés n'existent pas.")
+        return response.redirect().back()
+      }
+    }
+
     const project = await this.projectService.createProject(payload, user.id)
 
     return response.status(201).json({
@@ -43,10 +101,62 @@ export default class ProjectsController {
     })
   }
 
-  async update({ auth, request, response }: HttpContext) {
+  async update({ auth, request, response, session }: HttpContext) {
     const user = auth.getUserOrFail()
-    const { params, ...payload } = await request.validateUsing(updateProjectValidator)
-    const project = await this.projectService.updateProject(params.projectId, user.id, payload)
+    const { params, parcelleIds, exploitationIds, captageIds, ...payload } =
+      await request.validateUsing(updateProjectValidator)
+
+    if (exploitationIds !== undefined && exploitationIds.length > 0) {
+      const found = await this.exploitationService
+        .queryActiveExploitations(user.id)
+        .whereIn('id', exploitationIds)
+        .count('* as total')
+        .first()
+      if (Number(found?.$extras.total) !== exploitationIds.length) {
+        createErrorFlashMessage(
+          session,
+          "Certaines exploitations désignées n'existent pas ou ne vous appartiennent pas."
+        )
+        return response.redirect().back()
+      }
+    }
+
+    if (parcelleIds !== undefined && parcelleIds.length > 0) {
+      const found = await Parcelle.query()
+        .whereIn('id', parcelleIds)
+        .whereNull('exploitation_id')
+        .orWhereHas('exploitation', (exploitationQuery) => {
+          exploitationQuery.whereHas('territoires', (territoireQuery) => {
+            territoireQuery.whereHas('users', (userQuery) => {
+              userQuery.where('users.id', user.id)
+            })
+          })
+        })
+        .count('* as total')
+        .first()
+      if (Number(found?.$extras.total) !== parcelleIds.length) {
+        createErrorFlashMessage(
+          session,
+          "Certaines parcelles désignées n'existent pas ou appartiennent à des exploitations auxquelles vous n'avez pas accès."
+        )
+        return response.redirect().back()
+      }
+    }
+
+    if (captageIds !== undefined && captageIds.length > 0) {
+      const found = await Captage.query().whereIn('id', captageIds).count('* as total').first()
+      if (Number(found?.$extras.total) !== captageIds.length) {
+        createErrorFlashMessage(session, "Certains captages désignés n'existent pas.")
+        return response.redirect().back()
+      }
+    }
+
+    const project = await this.projectService.updateProject(params.projectId, user.id, {
+      ...payload,
+      parcelleIds,
+      exploitationIds,
+      captageIds,
+    })
 
     return response.json({
       data: ProjectDto.fromModel(project),

--- a/app/controllers/projects_controller.ts
+++ b/app/controllers/projects_controller.ts
@@ -64,11 +64,13 @@ export default class ProjectsController {
     if (payload.parcelleIds?.length) {
       const found = await Parcelle.query()
         .whereIn('id', payload.parcelleIds)
-        .whereNull('exploitation_id')
-        .orWhereHas('exploitation', (exploitationQuery) => {
-          exploitationQuery.whereHas('territoires', (territoireQuery) => {
-            territoireQuery.whereHas('users', (userQuery) => {
-              userQuery.where('users.id', user.id)
+        .andWhere((query) => {
+          // We want to find parcelles that have no exploitation or that have an exploitation that belongs to the currect user
+          query.whereNull('exploitation_id').orWhereHas('exploitation', (exploitationQuery) => {
+            exploitationQuery.whereHas('territoires', (territoireQuery) => {
+              territoireQuery.whereHas('users', (userQuery) => {
+                userQuery.where('users.id', user.id)
+              })
             })
           })
         })
@@ -124,11 +126,13 @@ export default class ProjectsController {
     if (parcelleIds !== undefined && parcelleIds.length > 0) {
       const found = await Parcelle.query()
         .whereIn('id', parcelleIds)
-        .whereNull('exploitation_id')
-        .orWhereHas('exploitation', (exploitationQuery) => {
-          exploitationQuery.whereHas('territoires', (territoireQuery) => {
-            territoireQuery.whereHas('users', (userQuery) => {
-              userQuery.where('users.id', user.id)
+        .andWhere((query) => {
+          // We want to find parcelles that have no exploitation or that have an exploitation that belongs to the currect user
+          query.whereNull('exploitation_id').orWhereHas('exploitation', (exploitationQuery) => {
+            exploitationQuery.whereHas('territoires', (territoireQuery) => {
+              territoireQuery.whereHas('users', (userQuery) => {
+                userQuery.where('users.id', user.id)
+              })
             })
           })
         })

--- a/app/services/project_service.ts
+++ b/app/services/project_service.ts
@@ -1,15 +1,33 @@
 import Project, { ProjectStatus } from '#models/project'
 import { ModelAttributes } from '@adonisjs/lucid/types/model'
 
+export interface ProjectPayload extends Partial<ModelAttributes<Project>> {
+  parcelleIds?: string[]
+  exploitationIds?: string[]
+  captageIds?: string[]
+}
+
 export class ProjectService {
-  async createProject(payload: Partial<ModelAttributes<Project>>, userId: string) {
-    return Project.create({
+  async createProject(payload: ProjectPayload, userId: string) {
+    const project = await Project.create({
       name: payload.name,
       description: payload.description ?? null,
       actionType: payload.actionType ?? null,
       status: payload.status ?? ProjectStatus.TO_BE_STARTED,
       userId,
     })
+
+    if (payload.parcelleIds?.length) {
+      await project.related('parcelles').attach(payload.parcelleIds)
+    }
+    if (payload.exploitationIds?.length) {
+      await project.related('exploitations').attach(payload.exploitationIds)
+    }
+    if (payload.captageIds?.length) {
+      await project.related('captages').attach(payload.captageIds)
+    }
+
+    return project
   }
 
   async findOwnedProjectOrFail(projectId: string, userId: string) {
@@ -22,15 +40,22 @@ export class ProjectService {
     await project.delete()
   }
 
-  async updateProject(
-    projectId: string,
-    userId: string,
-    payload: Partial<ModelAttributes<Project>>
-  ) {
+  async updateProject(projectId: string, userId: string, payload: ProjectPayload) {
     const project = await this.findOwnedProjectOrFail(projectId, userId)
+    const { parcelleIds, exploitationIds, captageIds, ...projectPayload } = payload
 
-    project.merge(payload)
+    project.merge(projectPayload)
     await project.save()
+
+    if (parcelleIds !== undefined) {
+      await project.related('parcelles').sync(parcelleIds)
+    }
+    if (exploitationIds !== undefined) {
+      await project.related('exploitations').sync(exploitationIds)
+    }
+    if (captageIds !== undefined) {
+      await project.related('captages').sync(captageIds)
+    }
 
     return project
   }

--- a/app/validators/project.ts
+++ b/app/validators/project.ts
@@ -8,6 +8,9 @@ export const createProjectValidator = vine.compile(
     description: vine.string().maxLength(4000).optional().nullable(),
     actionType: vine.string().maxLength(255).optional().nullable(),
     status: vine.enum(Object.values(ProjectStatus)).optional(),
+    parcelleIds: vine.array(vine.string().uuid()).optional(),
+    exploitationIds: vine.array(vine.string().uuid()).optional(),
+    captageIds: vine.array(vine.string().uuid()).optional(),
   })
 )
 
@@ -37,6 +40,9 @@ export const updateProjectValidator = vine.compile(
       .optional()
       .nullable()
       .transform((value) => (value ? DateTime.fromJSDate(value) : value)),
+    parcelleIds: vine.array(vine.string().uuid()).optional(),
+    exploitationIds: vine.array(vine.string().uuid()).optional(),
+    captageIds: vine.array(vine.string().uuid()).optional(),
     params: vine.object({
       projectId: vine.string().uuid(),
     }),

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -18,7 +18,7 @@ const VisualisationController = () => import('#controllers/visualisation_control
 const AacController = () => import('#controllers/aac_controller')
 const ProjectsController = () => import('#controllers/projects_controller')
 
-router.get('/', ({ response }) => response.redirect('login'))
+router.get('/', ({ response }) => response.redirect('login')).as('root')
 
 router.get('login', [SessionController, 'index'])
 router.post('login', [SessionController, 'store'])

--- a/tests/functional/exploitation/parcelle_note.spec.ts
+++ b/tests/functional/exploitation/parcelle_note.spec.ts
@@ -33,9 +33,7 @@ test.group('Parcelle - Note', (group) => {
       .loginAs(user)
       .withCsrfToken()
 
-    response.assertRedirectsTo(
-      `/visualisation?exploitationId=${exploitation.id}&parcelleId=${RPG_ID}&millesime=${YEAR}`
-    )
+    response.assertRedirectsTo(route('root'))
 
     const updatedParcelle = await Parcelle.query()
       .where('rpgId', RPG_ID)
@@ -65,9 +63,7 @@ test.group('Parcelle - Note', (group) => {
       .loginAs(user)
       .withCsrfToken()
 
-    response.assertRedirectsTo(
-      `/visualisation?exploitationId=${exploitation.id}&parcelleId=${RPG_ID}&millesime=${YEAR}`
-    )
+    response.assertRedirectsTo(route('root'))
 
     const updatedParcelle = await Parcelle.query()
       .where('rpgId', RPG_ID)

--- a/tests/functional/project/projects_store.spec.ts
+++ b/tests/functional/project/projects_store.spec.ts
@@ -2,6 +2,10 @@ import testUtils from '@adonisjs/core/services/test_utils'
 import { test } from '@japa/runner'
 import Project, { ProjectStatus } from '#models/project'
 import { UserFactory } from '#database/factories/user_factory'
+import { ExploitationFactory } from '#database/factories/exploitation_factory'
+import { ParcelleFactory } from '#database/factories/parcelle_factory'
+import { CaptageFactory } from '#database/factories/captage_factory'
+import { TerritoireFactory } from '#database/factories/territoire_factory'
 
 test.group('Projects - Store Route', (group) => {
   group.each.setup(() => testUtils.db().withGlobalTransaction())
@@ -84,5 +88,144 @@ test.group('Projects - Store Route', (group) => {
       .withCsrfToken()
 
     response.assertStatus(422)
+  })
+
+  test('I can create a project with accessible exploitations', async ({
+    assert,
+    client,
+    route,
+  }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const exploitation = await ExploitationFactory.create()
+    await exploitation.related('territoires').attach([territoire.id])
+
+    const response = await client
+      .post(route('projets.store'))
+      .loginAs(user)
+      .json({
+        name: 'Project with exploitations',
+        exploitationIds: [exploitation.id],
+      })
+      .withCsrfToken()
+
+    response.assertStatus(201)
+
+    const body = response.body() as { data: { id: string } }
+    const savedProject = await Project.findOrFail(body.data.id)
+    await savedProject.load('exploitations')
+
+    assert.equal(savedProject.exploitations.length, 1)
+    assert.equal(savedProject.exploitations[0].id, exploitation.id)
+  })
+
+  test("I can't create a project with exploitations not accessible to the user", async ({
+    client,
+    route,
+  }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const exploitation = await ExploitationFactory.create()
+    // No shared territoire between user and exploitation
+
+    const response = await client
+      .post(route('projets.store'))
+      .loginAs(user)
+      .json({
+        name: 'Project with inaccessible exploitations',
+        exploitationIds: [exploitation.id],
+      })
+      .withCsrfToken()
+
+    response.assertRedirectsTo(route('root'))
+  })
+
+  test('I can create a project with accessible parcelles', async ({ assert, client, route }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const exploitation = await ExploitationFactory.create()
+    await exploitation.related('territoires').attach([territoire.id])
+
+    const parcelle = await ParcelleFactory.merge({ exploitationId: exploitation.id }).create()
+
+    const response = await client
+      .post(route('projets.store'))
+      .loginAs(user)
+      .json({
+        name: 'Project with parcelles',
+        parcelleIds: [parcelle.id],
+      })
+      .withCsrfToken()
+
+    response.assertStatus(201)
+
+    const body = response.body() as { data: { id: string } }
+    const savedProject = await Project.findOrFail(body.data.id)
+    await savedProject.load('parcelles')
+
+    assert.equal(savedProject.parcelles.length, 1)
+    assert.equal(savedProject.parcelles[0].id, parcelle.id)
+  })
+
+  test("I can't create a project with parcelles not accessible to the user", async ({
+    client,
+    route,
+  }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    // Exploitation without shared territoire with the user
+    const exploitation = await ExploitationFactory.create()
+    const parcelle = await ParcelleFactory.merge({ exploitationId: exploitation.id }).create()
+
+    const response = await client
+      .post(route('projets.store'))
+      .loginAs(user)
+      .json({
+        name: 'Project with inaccessible parcelles',
+        parcelleIds: [parcelle.id],
+      })
+      .withCsrfToken()
+
+    response.assertRedirectsTo(route('root'))
+  })
+
+  test('I can create a project with existing captages', async ({ assert, client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const captage = await CaptageFactory.create()
+
+    const response = await client
+      .post(route('projets.store'))
+      .loginAs(user)
+      .json({
+        name: 'Project with captages',
+        captageIds: [captage.id],
+      })
+      .withCsrfToken()
+
+    response.assertStatus(201)
+
+    const body = response.body() as { data: { id: string } }
+    const savedProject = await Project.findOrFail(body.data.id)
+    await savedProject.load('captages')
+
+    assert.equal(savedProject.captages.length, 1)
+    assert.equal(savedProject.captages[0].id, captage.id)
+  })
+
+  test("I can't create a project with nonexistent captage ids", async ({ client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+
+    const response = await client
+      .post(route('projets.store'))
+      .loginAs(user)
+      .json({
+        name: 'Project with bad captages',
+        captageIds: ['00000000-0000-0000-0000-000000000000'],
+      })
+      .withCsrfToken()
+
+    response.assertRedirectsTo(route('root'))
   })
 })

--- a/tests/functional/project/projects_update.spec.ts
+++ b/tests/functional/project/projects_update.spec.ts
@@ -3,6 +3,10 @@ import { test } from '@japa/runner'
 import Project, { ProjectStatus } from '#models/project'
 import { UserFactory } from '#database/factories/user_factory'
 import { ProjectFactory } from '#database/factories/project_factory'
+import { ExploitationFactory } from '#database/factories/exploitation_factory'
+import { ParcelleFactory } from '#database/factories/parcelle_factory'
+import { CaptageFactory } from '#database/factories/captage_factory'
+import { TerritoireFactory } from '#database/factories/territoire_factory'
 
 test.group('Projects - Update Route', (group) => {
   group.each.setup(() => testUtils.db().withGlobalTransaction())
@@ -97,5 +101,152 @@ test.group('Projects - Update Route', (group) => {
       .withCsrfToken()
 
     response.assertStatus(422)
+  })
+
+  test('I can update a project with accessible exploitations', async ({
+    assert,
+    client,
+    route,
+  }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const exploitation = await ExploitationFactory.create()
+    await exploitation.related('territoires').attach([territoire.id])
+
+    const response = await client
+      .patch(route('projets.update', { projectId: project.id }))
+      .loginAs(user)
+      .json({ exploitationIds: [exploitation.id] })
+      .withCsrfToken()
+
+    response.assertStatus(200)
+
+    await project.load('exploitations')
+    assert.equal(project.exploitations.length, 1)
+    assert.equal(project.exploitations[0].id, exploitation.id)
+  })
+
+  test("I can't update a project with inaccessible exploitations", async ({ client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const exploitation = await ExploitationFactory.create()
+    // No shared territoire
+
+    const response = await client
+      .patch(route('projets.update', { projectId: project.id }))
+      .loginAs(user)
+      .json({ exploitationIds: [exploitation.id] })
+      .withCsrfToken()
+
+    response.assertRedirectsTo(route('root'))
+  })
+
+  test('I can update a project with accessible parcelles', async ({ assert, client, route }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const exploitation = await ExploitationFactory.create()
+    await exploitation.related('territoires').attach([territoire.id])
+    const parcelle = await ParcelleFactory.merge({ exploitationId: exploitation.id }).create()
+
+    const response = await client
+      .patch(route('projets.update', { projectId: project.id }))
+      .loginAs(user)
+      .json({ parcelleIds: [parcelle.id] })
+      .withCsrfToken()
+
+    response.assertStatus(200)
+
+    await project.load('parcelles')
+    assert.equal(project.parcelles.length, 1)
+    assert.equal(project.parcelles[0].id, parcelle.id)
+  })
+
+  test("I can't update a project with inaccessible parcelles", async ({ client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const exploitation = await ExploitationFactory.create()
+    const parcelle = await ParcelleFactory.merge({ exploitationId: exploitation.id }).create()
+    // No shared territoire between user and exploitation
+
+    const response = await client
+      .patch(route('projets.update', { projectId: project.id }))
+      .loginAs(user)
+      .json({ parcelleIds: [parcelle.id] })
+      .withCsrfToken()
+
+    response.assertRedirectsTo(route('root'))
+  })
+
+  test('I can update a project with existing captages', async ({ assert, client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const captage = await CaptageFactory.create()
+
+    const response = await client
+      .patch(route('projets.update', { projectId: project.id }))
+      .loginAs(user)
+      .json({ captageIds: [captage.id] })
+      .withCsrfToken()
+
+    response.assertStatus(200)
+
+    await project.load('captages')
+    assert.equal(project.captages.length, 1)
+    assert.equal(project.captages[0].id, captage.id)
+  })
+
+  test("I can't update a project with nonexistent captage ids", async ({ client, route }) => {
+    const user = await UserFactory.with('territoires', 1).create()
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const response = await client
+      .patch(route('projets.update', { projectId: project.id }))
+      .loginAs(user)
+      .json({ captageIds: ['00000000-0000-0000-0000-000000000000'] })
+      .withCsrfToken()
+
+    response.assertRedirectsTo(route('root'))
+  })
+
+  test('Updating relations syncs and replaces previous ones', async ({ assert, client, route }) => {
+    const territoire = await TerritoireFactory.create()
+    const user = await UserFactory.create()
+    await user.related('territoires').attach([territoire.id])
+
+    const project = await ProjectFactory.with('user').create()
+    await project.related('user').associate(user)
+
+    const captageA = await CaptageFactory.create()
+    const captageB = await CaptageFactory.create()
+    await project.related('captages').attach([captageA.id])
+
+    const response = await client
+      .patch(route('projets.update', { projectId: project.id }))
+      .loginAs(user)
+      .json({ captageIds: [captageB.id] })
+      .withCsrfToken()
+
+    response.assertStatus(200)
+
+    await project.load('captages')
+    assert.equal(project.captages.length, 1)
+    assert.equal(project.captages[0].id, captageB.id)
   })
 })


### PR DESCRIPTION
Dans le cadre du développement du module projet #388, cette PR ajoute la possibilité dans le back-end seulement d'ajouter/supprimer des exploitations, parcelles, captages aux entités de projet.

Il reste encore à ajouter la gestion des étapes de projet pour compléter le back-end de la feature.

Elle répare également d'anciens tests qui ne passaient plus suite à un changement de la gestion des redirections. Tous les tests ne passent pas encore.