### PR TITLE
Ajout des migrations/modèles/services de gestion des étapes de projet

### DIFF
--- a/app/models/project.ts
+++ b/app/models/project.ts
@@ -1,11 +1,19 @@
 import { DateTime } from 'luxon'
-import { BaseModel, beforeCreate, belongsTo, column, manyToMany } from '@adonisjs/lucid/orm'
-import type { BelongsTo, ManyToMany } from '@adonisjs/lucid/types/relations'
+import {
+  BaseModel,
+  beforeCreate,
+  belongsTo,
+  column,
+  hasMany,
+  manyToMany,
+} from '@adonisjs/lucid/orm'
+import type { BelongsTo, HasMany, ManyToMany } from '@adonisjs/lucid/types/relations'
 import { randomUUID } from 'node:crypto'
 import Exploitation from '#models/exploitation'
 import Parcelle from '#models/parcelle'
 import Captage from '#models/captage'
 import User from '#models/user'
+import ProjectStep from '#models/project_step'
 
 export const ProjectStatus = {
   TO_BE_STARTED: 'to_be_started',
@@ -61,6 +69,9 @@ export default class Project extends BaseModel {
     pivotTimestamps: true,
   })
   declare captages: ManyToMany<typeof Captage>
+
+  @hasMany(() => ProjectStep)
+  declare steps: HasMany<typeof ProjectStep>
 
   @column.dateTime()
   declare closedAt: DateTime | null

--- a/app/models/project_step.ts
+++ b/app/models/project_step.ts
@@ -1,0 +1,62 @@
+import { DateTime } from 'luxon'
+import {
+  BaseModel,
+  beforeCreate,
+  belongsTo,
+  column,
+  hasMany,
+  manyToMany,
+} from '@adonisjs/lucid/orm'
+import { randomUUID } from 'node:crypto'
+import type { BelongsTo, HasMany, ManyToMany } from '@adonisjs/lucid/types/relations'
+import Project from '#models/project'
+import ProjectStepTag from '#models/project_step_tag'
+import ProjectStepDocument from '#models/project_step_document'
+
+export const ProjectStepTagsRelationTable = 'project_step_tag_relations'
+
+export default class ProjectStep extends BaseModel {
+  static table = 'project_steps'
+  static selfAssignPrimaryKey = true
+
+  @column({ isPrimary: true })
+  declare id: string
+
+  @beforeCreate()
+  static assignUuid(step: ProjectStep) {
+    step.id = randomUUID()
+  }
+
+  @column()
+  declare projectId: string
+
+  @belongsTo(() => Project)
+  declare project: BelongsTo<typeof Project>
+
+  @column()
+  declare title: string
+
+  @column()
+  declare note: string | null
+
+  @column.date()
+  declare date: DateTime | null
+
+  @column()
+  declare isValidated: boolean
+
+  @manyToMany(() => ProjectStepTag, {
+    pivotTable: ProjectStepTagsRelationTable,
+    pivotTimestamps: true,
+  })
+  declare tags: ManyToMany<typeof ProjectStepTag>
+
+  @hasMany(() => ProjectStepDocument)
+  declare documents: HasMany<typeof ProjectStepDocument>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/app/models/project_step_document.ts
+++ b/app/models/project_step_document.ts
@@ -1,0 +1,43 @@
+import { DateTime } from 'luxon'
+import { BaseModel, beforeDelete, belongsTo, column } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import ProjectStep from '#models/project_step'
+import { ProjectStepDocumentService } from '#services/project_step_document_service'
+
+export default class ProjectStepDocument extends BaseModel {
+  static table = 'project_step_documents'
+
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare projectStepId: string
+
+  @belongsTo(() => ProjectStep)
+  declare projectStep: BelongsTo<typeof ProjectStep>
+
+  @column()
+  declare name: string
+
+  @column({ columnName: 's3_key' })
+  declare s3Key: string
+
+  @column()
+  declare sizeInBytes: number
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  @beforeDelete()
+  static async beforeDeleteHook(document: ProjectStepDocument) {
+    const service = new ProjectStepDocumentService()
+    try {
+      await service.deleteDocument(document.s3Key)
+    } catch (error) {
+      console.error(`Failed to delete document from S3 with key ${document.s3Key}:`, error)
+    }
+  }
+}

--- a/app/models/project_step_tag.ts
+++ b/app/models/project_step_tag.ts
@@ -1,0 +1,26 @@
+import { DateTime } from 'luxon'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import User from '#models/user'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+
+export default class ProjectStepTag extends BaseModel {
+  static table = 'project_step_tags'
+
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare name: string
+
+  @column()
+  declare userId: string
+
+  @belongsTo(() => User)
+  declare owner: BelongsTo<typeof User>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/app/models/project_step_tag.ts
+++ b/app/models/project_step_tag.ts
@@ -1,7 +1,8 @@
 import { DateTime } from 'luxon'
-import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import { BaseModel, belongsTo, column, manyToMany } from '@adonisjs/lucid/orm'
 import User from '#models/user'
-import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import type { BelongsTo, ManyToMany } from '@adonisjs/lucid/types/relations'
+import ProjectStep from '#models/project_step'
 
 export default class ProjectStepTag extends BaseModel {
   static table = 'project_step_tags'
@@ -17,6 +18,12 @@ export default class ProjectStepTag extends BaseModel {
 
   @belongsTo(() => User)
   declare owner: BelongsTo<typeof User>
+
+  @manyToMany(() => ProjectStep, {
+    pivotTable: 'project_step_tag_relations',
+    pivotTimestamps: true,
+  })
+  declare steps: ManyToMany<typeof ProjectStep>
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime

--- a/app/services/base_document_upload_service.ts
+++ b/app/services/base_document_upload_service.ts
@@ -1,0 +1,75 @@
+import { cuid } from '@adonisjs/core/helpers'
+import drive from '@adonisjs/drive/services/main'
+import path from 'node:path'
+
+export interface MultipartFileLike {
+  clientName?: string
+  fileName?: string
+  size: number
+  moveToDisk: (destination: string) => Promise<void>
+}
+
+// Base service to store and retrieve documents from a distant S3 bucket.
+export abstract class BaseDocumentUploadService {
+  /*
+   * Generate a unique key for the document.
+   * The key will be used as the filename in the S3 bucket. Store it in the DB to retrieve the document later.
+   */
+  static getKey(filename: string | undefined): string {
+    if (!filename) {
+      return `${cuid()}-document`
+    }
+
+    const base = path.basename(filename)
+    const lastDotIndex = base.lastIndexOf('.')
+    const extension = lastDotIndex > 0 ? filename.slice(lastDotIndex + 1) : ''
+    const basename = lastDotIndex > 0 ? filename.slice(0, lastDotIndex) : base
+
+    const safeName = basename
+      .replace(/[^a-zA-Z0-9_-]/g, '_')
+      // Limit the length of the filename to prevent excessively long keys
+      .slice(0, 100)
+
+    const safeExtension = extension
+      .replace(/[^a-zA-Z0-9]/g, '')
+      .toLowerCase()
+      .slice(0, 10)
+
+    const finalName = safeName || 'document'
+    return safeExtension ? `${cuid()}-${finalName}.${safeExtension}` : `${cuid()}-${finalName}`
+  }
+
+  /*
+   * Get the full S3 path for a given key, by adding the prefix.
+   * Must be overridden by subclasses to define their specific S3 prefix.
+   * Implementation should look like `return prefix + '/' + key`.
+   */
+  protected abstract getS3Path(key: string): string
+
+  /*
+   * Upload the document to the S3 bucket and return the generated key.
+   * See https://docs.adonisjs.com/guides/digging-deeper/drive#usage
+   */
+  public async uploadDocument(file: MultipartFileLike): Promise<string> {
+    const filename = file.clientName || file.fileName || 'document'
+    const key = BaseDocumentUploadService.getKey(filename)
+    await file.moveToDisk(this.getS3Path(key))
+    return key
+  }
+
+  /*
+   * Delete the document from the S3 bucket using its key.
+   */
+  public async deleteDocument(fileKey: string): Promise<void> {
+    const disk = drive.use()
+    await disk.delete(this.getS3Path(fileKey))
+  }
+
+  /*
+   * Get a signed URL to access the document from the S3 bucket using its key.
+   */
+  public async getDocumentUrl(fileKey: string): Promise<string> {
+    const disk = drive.use()
+    return disk.getSignedUrl(this.getS3Path(fileKey))
+  }
+}

--- a/app/services/project_step_document_service.ts
+++ b/app/services/project_step_document_service.ts
@@ -1,28 +1,28 @@
-import LogEntryDocument from '#models/log_entry_document'
+import ProjectStepDocument from '#models/project_step_document'
 import {
   BaseDocumentUploadService,
   type MultipartFileLike,
 } from '#services/base_document_upload_service'
 
-// Service to store and retrieve log entry documents from a distant S3 bucket.
-export class LogEntryDocumentService extends BaseDocumentUploadService {
+// Service to store and retrieve project step documents from a distant S3 bucket.
+export class ProjectStepDocumentService extends BaseDocumentUploadService {
   /*
    * Get the full S3 path for a given key, by adding the prefix.
    */
   getS3Path(key: string): string {
-    return `log-entries-documents/${key}`
+    return `project-steps-documents/${key}`
   }
 
   /*
-   * Create a new LogEntryDocument record in the database with the given information.
+   * Create a new ProjectStepDocument record in the database with the given information.
    */
-  public async createDocument(logEntryId: string, document: MultipartFileLike) {
+  public async createDocument(projectStepId: string, document: MultipartFileLike) {
     const fileName = document.clientName || document.fileName || 'document'
     const key = await this.uploadDocument(document)
 
     try {
-      return await LogEntryDocument.create({
-        logEntryId: logEntryId,
+      return await ProjectStepDocument.create({
+        projectStepId: projectStepId,
         name: fileName,
         sizeInBytes: document.size,
         s3Key: key,

--- a/app/services/project_step_service.ts
+++ b/app/services/project_step_service.ts
@@ -1,0 +1,71 @@
+import { ModelAttributes } from '@adonisjs/lucid/types/model'
+import ProjectStep from '#models/project_step'
+import ProjectStepDocument from '#models/project_step_document'
+import Project from '#models/project'
+
+export class ProjectStepService {
+  async createStep(
+    project: Project,
+    data: Partial<ModelAttributes<ProjectStep>>,
+    tagsIds?: number[]
+  ) {
+    const step = await ProjectStep.create({ ...data, projectId: project.id })
+
+    if (tagsIds && tagsIds.length > 0) {
+      await step.related('tags').attach(tagsIds)
+    }
+
+    return step
+  }
+
+  async getStepsForProject(project: Project) {
+    return ProjectStep.query()
+      .where('projectId', project.id)
+      .preload('tags')
+      .preload('documents')
+      .orderBy('createdAt', 'desc')
+  }
+
+  async updateStep(
+    stepId: string,
+    project: Project,
+    data: Partial<ModelAttributes<ProjectStep>>,
+    tagsIds?: number[]
+  ) {
+    const step = await ProjectStep.query()
+      .where('id', stepId)
+      .andWhere('projectId', project.id)
+      .firstOrFail()
+
+    step.merge(data)
+    await step.save()
+
+    if (tagsIds !== undefined) {
+      await step.related('tags').sync(tagsIds)
+    }
+
+    return step
+  }
+
+  async deleteStep(stepId: string, project: Project) {
+    const step = await ProjectStep.query()
+      .where('id', stepId)
+      .andWhere('projectId', project.id)
+      .firstOrFail()
+
+    await step.delete()
+
+    return step
+  }
+
+  async findDocument(documentId: number, userId: string) {
+    return ProjectStepDocument.query()
+      .where('id', documentId)
+      .andWhereHas('projectStep', (stepQuery) => {
+        stepQuery.whereHas('project', (projectQuery) => {
+          projectQuery.where('userId', userId)
+        })
+      })
+      .first()
+  }
+}

--- a/app/services/project_step_tag_service.ts
+++ b/app/services/project_step_tag_service.ts
@@ -1,6 +1,6 @@
 import ProjectStepTag from '#models/project_step_tag'
-import ProjectStep from '#models/project_step'
 import { errors } from '@adonisjs/auth'
+import ProjectStep from '#models/project_step'
 
 export class ProjectStepTagService {
   async createTagForUser(userId: string, tagName: string) {
@@ -24,14 +24,12 @@ export class ProjectStepTagService {
     return query.exec()
   }
 
-  async getTagsForStep(stepId?: string) {
-    if (!stepId) {
-      return []
-    }
-
-    const step = await ProjectStep.query().where('id', stepId).preload('tags').firstOrFail()
-
-    return step.tags
+  async getTagsForStep(stepId: string) {
+    return ProjectStepTag.query()
+      .whereHas('steps', (query) => {
+        query.where(`${ProjectStep.table}.id`, stepId)
+      })
+      .exec()
   }
 
   async updateTag(tagId: number, tagName: string, userId: string) {

--- a/app/services/project_step_tag_service.ts
+++ b/app/services/project_step_tag_service.ts
@@ -1,0 +1,59 @@
+import ProjectStepTag from '#models/project_step_tag'
+import ProjectStep from '#models/project_step'
+import { errors } from '@adonisjs/auth'
+
+export class ProjectStepTagService {
+  async createTagForUser(userId: string, tagName: string) {
+    return await ProjectStepTag.create({
+      name: tagName,
+      userId,
+    })
+  }
+
+  async getTagsForUser(userId: string, searchQuery?: string, limit?: number) {
+    const query = ProjectStepTag.query().where('userId', userId).orderBy('updatedAt', 'desc')
+
+    if (searchQuery) {
+      query.andWhere('name', 'ilike', `%${searchQuery}%`)
+    }
+
+    if (limit) {
+      query.limit(limit)
+    }
+
+    return query.exec()
+  }
+
+  async getTagsForStep(stepId?: string) {
+    if (!stepId) {
+      return []
+    }
+
+    const step = await ProjectStep.query().where('id', stepId).preload('tags').firstOrFail()
+
+    return step.tags
+  }
+
+  async updateTag(tagId: number, tagName: string, userId: string) {
+    const tag = await ProjectStepTag.findOrFail(tagId)
+
+    if (tag.userId !== userId) {
+      throw errors.E_UNAUTHORIZED_ACCESS
+    }
+
+    tag.name = tagName
+    await tag.save()
+    return tag
+  }
+
+  async deleteTag(tagId: number, userId: string) {
+    const tag = await ProjectStepTag.findOrFail(tagId)
+
+    if (tag.userId !== userId) {
+      throw errors.E_UNAUTHORIZED_ACCESS
+    }
+
+    await tag.delete()
+    return tag
+  }
+}

--- a/database/factories/project_step_factory.ts
+++ b/database/factories/project_step_factory.ts
@@ -1,0 +1,17 @@
+import factory from '@adonisjs/lucid/factories'
+import { fakerFR as faker } from '@faker-js/faker'
+import ProjectStep from '#models/project_step'
+import { ProjectFactory } from '#database/factories/project_factory'
+import { ProjectStepTagFactory } from '#database/factories/project_step_tag_factory'
+
+export const ProjectStepFactory = factory
+  .define(ProjectStep, async () => {
+    return {
+      title: faker.lorem.sentence(),
+      note: faker.lorem.paragraph(),
+      isValidated: false,
+    }
+  })
+  .relation('project', () => ProjectFactory)
+  .relation('tags', () => ProjectStepTagFactory)
+  .build()

--- a/database/factories/project_step_tag_factory.ts
+++ b/database/factories/project_step_tag_factory.ts
@@ -1,0 +1,13 @@
+import factory from '@adonisjs/lucid/factories'
+import { fakerFR as faker } from '@faker-js/faker'
+import ProjectStepTag from '#models/project_step_tag'
+import { UserFactory } from '#database/factories/user_factory'
+
+export const ProjectStepTagFactory = factory
+  .define(ProjectStepTag, async () => {
+    return {
+      name: faker.lorem.word(),
+    }
+  })
+  .relation('owner', () => UserFactory)
+  .build()

--- a/database/migrations/1775000000005_create_project_step_tags_table.ts
+++ b/database/migrations/1775000000005_create_project_step_tags_table.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+import ProjectStepTag from '#models/project_step_tag'
+import User from '#models/user'
+
+export default class extends BaseSchema {
+  protected tableName = ProjectStepTag.table
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').unsigned()
+
+      table.string('name').notNullable()
+      table.uuid('user_id').references('id').inTable(User.table).onDelete('CASCADE').notNullable()
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/migrations/1775000000006_create_project_steps_table.ts
+++ b/database/migrations/1775000000006_create_project_steps_table.ts
@@ -1,0 +1,28 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'project_steps'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.uuid('id').primary().notNullable()
+      table
+        .uuid('project_id')
+        .notNullable()
+        .references('id')
+        .inTable('projects')
+        .onDelete('CASCADE')
+      table.string('title').notNullable()
+      table.text('note').nullable()
+      table.date('date').nullable()
+      table.boolean('is_validated').defaultTo(false).notNullable()
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/migrations/1775000000007_create_project_step_documents_table.ts
+++ b/database/migrations/1775000000007_create_project_step_documents_table.ts
@@ -1,0 +1,29 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+import ProjectStepDocument from '#models/project_step_document'
+
+export default class extends BaseSchema {
+  protected tableName = ProjectStepDocument.table
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+
+      table
+        .uuid('project_step_id')
+        .notNullable()
+        .references('id')
+        .inTable('project_steps')
+        .onDelete('CASCADE')
+      table.string('name').notNullable()
+      table.string('s3_key').notNullable()
+      table.integer('size_in_bytes').notNullable()
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/migrations/1775000000008_create_project_step_tag_relations_table.ts
+++ b/database/migrations/1775000000008_create_project_step_tag_relations_table.ts
@@ -1,0 +1,33 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+import { ProjectStepTagsRelationTable } from '#models/project_step'
+
+export default class extends BaseSchema {
+  protected tableName = ProjectStepTagsRelationTable
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table
+        .uuid('project_step_id')
+        .notNullable()
+        .references('id')
+        .inTable('project_steps')
+        .onDelete('CASCADE')
+      table
+        .integer('project_step_tag_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('project_step_tags')
+        .onDelete('CASCADE')
+
+      table.primary(['project_step_id', 'project_step_tag_id'])
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/database/migrations/1775000000008_create_project_step_tag_relations_table.ts
+++ b/database/migrations/1775000000008_create_project_step_tag_relations_table.ts
@@ -6,6 +6,8 @@ export default class extends BaseSchema {
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+
       table
         .uuid('project_step_id')
         .notNullable()
@@ -20,7 +22,7 @@ export default class extends BaseSchema {
         .inTable('project_step_tags')
         .onDelete('CASCADE')
 
-      table.primary(['project_step_id', 'project_step_tag_id'])
+      table.unique(['project_step_id', 'project_step_tag_id'])
 
       table.timestamp('created_at')
       table.timestamp('updated_at')

--- a/tests/unit/log_entry/log_entry_document_service.spec.ts
+++ b/tests/unit/log_entry/log_entry_document_service.spec.ts
@@ -16,12 +16,18 @@ test.group('LogEntryDocumentService', () => {
     /*
      * Generate a fake in-memory PDF file
      */
-    const { contents, mime, name } = await fileGenerator.generatePdf('1mb')
+    const { contents, name, size } = await fileGenerator.generatePdf('1mb')
 
     const service = new LogEntryDocumentService()
-    const key = await service.uploadDocument(contents, name, mime)
+    const key = await service.uploadDocument({
+      clientName: name,
+      size,
+      moveToDisk: async (destination: string) => {
+        await fakeDisk.put(destination, contents)
+      },
+    })
 
-    fakeDisk.assertExists(LogEntryDocumentService.getS3Path(key))
+    fakeDisk.assertExists(service.getS3Path(key))
 
     const url = await service.getDocumentUrl(key)
 
@@ -35,14 +41,20 @@ test.group('LogEntryDocumentService', () => {
     /*
      * Generate a fake in-memory PDF file
      */
-    const { contents, mime, name } = await fileGenerator.generatePdf('1mb')
+    const { contents, name, size } = await fileGenerator.generatePdf('1mb')
 
     const service = new LogEntryDocumentService()
-    const key = await service.uploadDocument(contents, name, mime)
+    const key = await service.uploadDocument({
+      clientName: name,
+      size,
+      moveToDisk: async (destination: string) => {
+        await fakeDisk.put(destination, contents)
+      },
+    })
 
     await service.deleteDocument(key)
 
-    fakeDisk.assertMissing(LogEntryDocumentService.getS3Path(key))
+    fakeDisk.assertMissing(service.getS3Path(key))
   })
 
   test('I can create a document record', async ({ cleanup, assert }) => {
@@ -68,6 +80,6 @@ test.group('LogEntryDocumentService', () => {
 
     assert.equal(document.logEntryId, logEntry.id)
     assert.equal(document.name, name)
-    fakeDisk.assertExists(LogEntryDocumentService.getS3Path(document.s3Key))
+    fakeDisk.assertExists(service.getS3Path(document.s3Key))
   })
 })

--- a/tests/unit/project/project_step_service.spec.ts
+++ b/tests/unit/project/project_step_service.spec.ts
@@ -1,0 +1,145 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { ProjectStepService } from '#services/project_step_service'
+import { UserFactory } from '#database/factories/user_factory'
+import { ProjectFactory } from '#database/factories/project_factory'
+import { ProjectStepTagFactory } from '#database/factories/project_step_tag_factory'
+import ProjectStepDocument from '#models/project_step_document'
+
+test.group('ProjectStepService', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('I can create a step', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const project = await ProjectFactory.merge({ userId: user.id }).create()
+    const tags = await ProjectStepTagFactory.merge({ userId: user.id }).createMany(3)
+
+    const service = new ProjectStepService()
+    const step = await service.createStep(
+      project,
+      { title: 'Step 1', note: 'A note' },
+      tags.map((t) => t.id)
+    )
+    await step.load('tags')
+
+    assert.exists(step.id)
+    assert.equal(step.title, 'Step 1')
+    assert.equal(step.note, 'A note')
+    assert.equal(step.projectId, project.id)
+    assert.equal(step.tags.length, 3)
+  })
+
+  test('I can get all steps for a project', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const project = await ProjectFactory.merge({ userId: user.id }).create()
+
+    const service = new ProjectStepService()
+    await service.createStep(project, { title: 'Step 1' })
+    await service.createStep(project, { title: 'Step 2' })
+    await service.createStep(project, { title: 'Step 3' })
+
+    const steps = await service.getStepsForProject(project)
+
+    assert.equal(steps.length, 3)
+    // Tags and documents should be preloaded
+    assert.isArray(steps[0].tags)
+    assert.isArray(steps[0].documents)
+  })
+
+  test('I can update a step', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const project = await ProjectFactory.merge({ userId: user.id }).create()
+
+    const service = new ProjectStepService()
+    const step = await service.createStep(project, { title: 'Original title' })
+
+    const updated = await service.updateStep(step.id, project, {
+      title: 'Updated title',
+      isValidated: true,
+    })
+
+    assert.equal(updated.title, 'Updated title')
+    assert.equal(updated.isValidated, true)
+  })
+
+  test('I can update the tags of a step', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const project = await ProjectFactory.merge({ userId: user.id }).create()
+    const initialTags = await ProjectStepTagFactory.merge({ userId: user.id }).createMany(2)
+    const newTags = await ProjectStepTagFactory.merge({ userId: user.id }).createMany(2)
+
+    const service = new ProjectStepService()
+    const step = await service.createStep(
+      project,
+      { title: 'Step' },
+      initialTags.map((t) => t.id)
+    )
+
+    const updated = await service.updateStep(
+      step.id,
+      project,
+      {},
+      newTags.map((t) => t.id)
+    )
+    await updated.load('tags')
+
+    assert.deepEqual(
+      updated.tags.map((t) => t.id),
+      newTags.map((t) => t.id)
+    )
+  })
+
+  test('I can delete a step', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const project = await ProjectFactory.merge({ userId: user.id }).create()
+
+    const service = new ProjectStepService()
+    const step = await service.createStep(project, { title: 'To delete' })
+
+    const deleted = await service.deleteStep(step.id, project)
+    assert.equal(deleted.id, step.id)
+
+    const remaining = await service.getStepsForProject(project)
+    assert.equal(remaining.length, 0)
+  })
+
+  test('I can find a document that belongs to one of my steps', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const project = await ProjectFactory.merge({ userId: user.id }).create()
+
+    const service = new ProjectStepService()
+    const step = await service.createStep(project, { title: 'Step with doc' })
+
+    const doc = await ProjectStepDocument.create({
+      projectStepId: step.id,
+      name: 'file.pdf',
+      s3Key: 's3/file.pdf',
+      sizeInBytes: 512,
+    })
+
+    const found = await service.findDocument(doc.id, user.id)
+
+    assert.isNotNull(found)
+    assert.equal(found!.id, doc.id)
+  })
+
+  test('I cannot find a document that belongs to another user', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const otherUser = await UserFactory.create()
+    const project = await ProjectFactory.merge({ userId: otherUser.id }).create()
+
+    const service = new ProjectStepService()
+    const step = await service.createStep(project, { title: 'Step' })
+
+    const doc = await ProjectStepDocument.create({
+      projectStepId: step.id,
+      name: 'secret.pdf',
+      s3Key: 's3/secret.pdf',
+      sizeInBytes: 1024,
+    })
+
+    const found = await service.findDocument(doc.id, user.id)
+
+    assert.isNull(found)
+  })
+})

--- a/tests/unit/project/project_step_tag_service.spec.ts
+++ b/tests/unit/project/project_step_tag_service.spec.ts
@@ -91,14 +91,6 @@ test.group('ProjectStepTagService', (group) => {
     assert.deepEqual(stepTags.map((t) => t.id).sort(), tags.map((t) => t.id).sort())
   })
 
-  test('getTagsForStep returns empty array when stepId is undefined', async ({ assert }) => {
-    const service = new ProjectStepTagService()
-
-    const tags = await service.getTagsForStep(undefined)
-
-    assert.deepEqual(tags, [])
-  })
-
   test('I can update a tag', async ({ assert }) => {
     const user = await UserFactory.create()
     const service = new ProjectStepTagService()

--- a/tests/unit/project/project_step_tag_service.spec.ts
+++ b/tests/unit/project/project_step_tag_service.spec.ts
@@ -1,0 +1,146 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { UserFactory } from '#database/factories/user_factory'
+import { ProjectFactory } from '#database/factories/project_factory'
+import { ProjectStepTagFactory } from '#database/factories/project_step_tag_factory'
+import { ProjectStepTagService } from '#services/project_step_tag_service'
+import { ProjectStepService } from '#services/project_step_service'
+
+test.group('ProjectStepTagService', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('I can create a tag for a user', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const service = new ProjectStepTagService()
+
+    const tag = await service.createTagForUser(user.id, 'Urgent')
+
+    assert.exists(tag.id)
+    assert.equal(tag.name, 'Urgent')
+    assert.equal(tag.userId, user.id)
+  })
+
+  test('I can fetch tags for a user', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const service = new ProjectStepTagService()
+
+    await service.createTagForUser(user.id, 'Urgent')
+    await service.createTagForUser(user.id, 'Follow-up')
+
+    const tags = await service.getTagsForUser(user.id)
+
+    assert.lengthOf(tags, 2)
+  })
+
+  test('Tags from another user are not returned', async ({ assert }) => {
+    const user1 = await UserFactory.create()
+    const user2 = await UserFactory.create()
+    const service = new ProjectStepTagService()
+
+    await service.createTagForUser(user1.id, 'Urgent')
+    await service.createTagForUser(user2.id, 'Follow-up')
+
+    const tags = await service.getTagsForUser(user1.id)
+
+    assert.lengthOf(tags, 1)
+    assert.equal(tags[0].name, 'Urgent')
+  })
+
+  test('I can filter tags by search query', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const service = new ProjectStepTagService()
+
+    await service.createTagForUser(user.id, 'Urgent')
+    await service.createTagForUser(user.id, 'Follow-up')
+    await service.createTagForUser(user.id, 'Urge me')
+
+    const tags = await service.getTagsForUser(user.id, 'Urge')
+
+    assert.lengthOf(tags, 2)
+  })
+
+  test('I can limit the number of tags returned', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const service = new ProjectStepTagService()
+
+    await service.createTagForUser(user.id, 'Tag 1')
+    await service.createTagForUser(user.id, 'Tag 2')
+    await service.createTagForUser(user.id, 'Tag 3')
+
+    const tags = await service.getTagsForUser(user.id, undefined, 2)
+
+    assert.lengthOf(tags, 2)
+  })
+
+  test('I can get tags for a step', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const project = await ProjectFactory.merge({ userId: user.id }).create()
+    const tags = await ProjectStepTagFactory.merge({ userId: user.id }).createMany(2)
+
+    const stepService = new ProjectStepService()
+    const step = await stepService.createStep(
+      project,
+      { title: 'Step' },
+      tags.map((t) => t.id)
+    )
+
+    const service = new ProjectStepTagService()
+    const stepTags = await service.getTagsForStep(step.id)
+
+    assert.lengthOf(stepTags, 2)
+    assert.deepEqual(stepTags.map((t) => t.id).sort(), tags.map((t) => t.id).sort())
+  })
+
+  test('getTagsForStep returns empty array when stepId is undefined', async ({ assert }) => {
+    const service = new ProjectStepTagService()
+
+    const tags = await service.getTagsForStep(undefined)
+
+    assert.deepEqual(tags, [])
+  })
+
+  test('I can update a tag', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const service = new ProjectStepTagService()
+
+    const tag = await service.createTagForUser(user.id, 'Urgent')
+    const updated = await service.updateTag(tag.id, 'High Priority', user.id)
+
+    assert.equal(updated.name, 'High Priority')
+  })
+
+  test("I cannot update a tag that doesn't belong to me", async ({ assert }) => {
+    const user1 = await UserFactory.create()
+    const user2 = await UserFactory.create()
+    const service = new ProjectStepTagService()
+
+    const tag = await service.createTagForUser(user1.id, 'Urgent')
+
+    await assert.rejects(async () => {
+      await service.updateTag(tag.id, 'High Priority', user2.id)
+    })
+  })
+
+  test('I can delete a tag', async ({ assert }) => {
+    const user = await UserFactory.create()
+    const service = new ProjectStepTagService()
+
+    const tag = await service.createTagForUser(user.id, 'Urgent')
+    await service.deleteTag(tag.id, user.id)
+
+    const tags = await service.getTagsForUser(user.id)
+    assert.lengthOf(tags, 0)
+  })
+
+  test("I cannot delete a tag that doesn't belong to me", async ({ assert }) => {
+    const user1 = await UserFactory.create()
+    const user2 = await UserFactory.create()
+    const service = new ProjectStepTagService()
+
+    const tag = await service.createTagForUser(user1.id, 'Urgent')
+
+    await assert.rejects(async () => {
+      await service.deleteTag(tag.id, user2.id)
+    })
+  })
+})


### PR DESCRIPTION
Dans le cadre de la fonctionnalité de la gestion des projets #388, cette PR ajoute la gestion des étapes de projet dans le back-end. Nommément les migrations, modèles et services liés aux étapes en elles même, mais aussi pour les tags et les documents uploadables. 

Les tags et documents fonctionnent de façon similaire aux entrées de journal de bord (log entries). Pour l'upload, le comportement en commun avec les log entries a été factorisé dans une classe abstraite.

Il n'y a pas encore de routes permettant d'accéder à toute cette logique métier, mais des tests unitaires permettent de tester le bon fonctionnement. Les routes arriveront dans une PR prochaine.