### PR TITLE
Correction de l'affichage des couleurs dans la répartitions des cultures

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ node ace migration:run
 node ace db:seed
 ```
 
+### Bucket dev <=> production
+
+Les fichiers en lecture seule du bucket ont deux dossiers pour éviter les problèmes en production (`api-aac` et `api-aac-dev`).
+Lors de la mise en production, il faut vérifier que le fichier dans `api-aac` est bien à jour.
+
 ## Exécution de Storybook
 
 ```shell

--- a/inertia/functions/cultures-group.tsx
+++ b/inertia/functions/cultures-group.tsx
@@ -151,33 +151,11 @@ export const GROUPES_CULTURAUX: { [key: string]: GroupeCulturauxItem } = {
   },
 }
 
-const CULTURE_CATEGORY_COLORS: Record<string, string> = {
-  'Céréales': groupColors[1],
-  'Oléagineux': groupColors[5],
-  'Protéagineux': groupColors[8],
-  'Plantes à fibres': groupColors[9],
-  'Semences': groupColors[10],
-  'Gel / jachère': groupColors[11],
-  'Légumineuses à grains': groupColors[15],
-  'Fourragères annuelles': groupColors[16],
-  'Fourragères (hors prairies)': groupColors[16],
-  'Estives et landes': groupColors[17],
-  'Prairies permanentes': groupColors[18],
-  'Prairies temporaires': groupColors[19],
-  'Vergers': groupColors[20],
-  'Vignes': groupColors[21],
-  'Fruits à coque': groupColors[22],
-  'Autres cultures industrielles': groupColors[24],
-  'Fleurs et horticulture': groupColors[25],
-  'Agroforesterie': groupColors[27],
-  'Divers': groupColors[28],
-  'Surfaces non agricoles': groupColors[28],
-  'Autres cultures permanentes': groupColors[27],
-  'Tubercules et racines industrielles': groupColors[24],
-}
-
 export function getCultureCategoryColor(name: string): string {
-  return CULTURE_CATEGORY_COLORS[name] ?? groupColors[28]
+  const color = Object.entries(GROUPES_CULTURAUX).find((label) => label[1].label === name)?.[1]
+    .color
+
+  return color ?? groupColors[28]
 }
 
 export function getCulturesGroup(code: string | number) {


### PR DESCRIPTION
Un utilisateur nous a remonté des différences de culture entre le graphique de répartition et le graphique d'évolution des cultures.

Après une correction au niveau du fichier parquet, les couleurs n'étaient plus détéctées.

Cette PR corrige l'affichage des couleurs en utilisant l'objet `GROUPES_CULTURAUX`.

Fix #430 

>[!WARNING]
> Le fichier `aac.parquet` doit être mis à jour avant la fusion de ces modifications.