### PR TITLE
Corrections de tests liés à l'export de données de qualité de l'eau

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
 
     services:
       postgres:
@@ -72,7 +72,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -41,7 +41,7 @@ jobs:
         image: postgres:16.9-alpine
         env:
           POSTGRES_USER: ${{ vars.DB_USER }}
-          POSTGRES_PASSWORD: ${{ vars.DB_PASSWORD }}
+          POSTGRES_PASSWORD: ${{ secrets.DB_PASSWORD }}
           POSTGRES_DB: ${{ vars.DB_DATABASE }}
         ports:
           - 5432:5432

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,12 +14,23 @@ jobs:
       APP_KEY: ${{ vars.APP_KEY }}
       DB_DATABASE: ${{ vars.DB_DATABASE }}
       DB_HOST: ${{ vars.DB_HOST }}
-      DB_PASSWORD: ${{ vars.DB_PASSWORD }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       DB_PORT: ${{ vars.DB_PORT }}
       DB_USER: ${{ vars.DB_USER }}
       HOST: ${{ vars.HOST }}
       LOG_LEVEL: ${{ vars.LOG_LEVEL }}
       SESSION_DRIVER: ${{ vars.SESSION_DRIVER }}
+      DRIVE_DISK: ${{ vars.DRIVE_DISK }}
+      SPACES_KEY: ${{ secrets.SPACES_KEY }}
+      SPACES_SECRET: ${{ secrets.SPACES_SECRET }}
+      SPACES_REGION: ${{ vars.SPACES_REGION }}
+      SPACES_BUCKET: ${{ vars.SPACES_BUCKET }}
+      SPACES_ENDPOINT: ${{ vars.SPACES_ENDPOINT }}
+      S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+      S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+      S3_REGION: ${{ vars.S3_REGION }}
+      S3_BUCKET: ${{ vars.S3_BUCKET }}
+      S3_ENDPOINT: ${{ vars.S3_ENDPOINT }}
 
     strategy:
       matrix:

--- a/app/services/aac_csv_service.ts
+++ b/app/services/aac_csv_service.ts
@@ -238,7 +238,12 @@ export class AacCsvService {
     const rows: string[] = []
 
     const codes = installations.map((inst) => inst.code)
-    const analyses = await this.aacService.getAnalysesRobinetForExport(codes)
+    let analyses: Record<string, unknown>[]
+    try {
+      analyses = await this.aacService.getAnalysesRobinetForExport(codes)
+    } catch {
+      return null
+    }
 
     if (analyses.length > 0 && Object.keys(analyses[0]).length > 0) {
       headers.push(...Object.keys(analyses[0]))

--- a/tests/unit/aac/aac_csv_service.spec.ts
+++ b/tests/unit/aac/aac_csv_service.spec.ts
@@ -68,6 +68,15 @@ function createMockAacService(fixture: AacJson | null): AacService {
     getAnalysesRobinet: async (_code: string, year: number) => [
       { date_prelevement: `${year}-03-15`, parametre: 'Nitrates', valeur: 42 },
     ],
+    getAnalysesRobinetForExport: async () => [
+      {
+        code_installation: 'INST1',
+        nom_installation: 'Installation 1',
+        date_prelevement: '2024-03-15',
+        parametre: 'Nitrates',
+        valeur: 42,
+      },
+    ],
   } as unknown as AacService
 }
 
@@ -217,6 +226,7 @@ test.group('AacCsvService - exportQualiteEau', () => {
       getByCode: async () => buildAacFixture() as unknown as Record<string, unknown>,
       getAnalysesRobinetYears: async () => [],
       getAnalysesRobinet: async () => [],
+      getAnalysesRobinetForExport: async () => [],
     } as unknown as AacService
     const service = new AacCsvService(mockService)
     const result = await service.exportQualiteEau('12345')
@@ -231,24 +241,10 @@ test.group('AacCsvService - exportQualiteEau', () => {
     assert.include(csv!, '"42"')
   })
 
-  test('continues gracefully when getAnalysesRobinetYears throws', async ({ assert }) => {
+  test('continues gracefully when getAnalysesRobinetForExport throws', async ({ assert }) => {
     const mockService = {
       getByCode: async () => buildAacFixture() as unknown as Record<string, unknown>,
-      getAnalysesRobinetYears: async () => {
-        throw new Error('S3 error')
-      },
-      getAnalysesRobinet: async () => [],
-    } as unknown as AacService
-    const service = new AacCsvService(mockService)
-    const result = await service.exportQualiteEau('12345')
-    assert.isNull(result)
-  })
-
-  test('continues gracefully when getAnalysesRobinet throws', async ({ assert }) => {
-    const mockService = {
-      getByCode: async () => buildAacFixture() as unknown as Record<string, unknown>,
-      getAnalysesRobinetYears: async () => ['2024'],
-      getAnalysesRobinet: async () => {
+      getAnalysesRobinetForExport: async () => {
         throw new Error('S3 error')
       },
     } as unknown as AacService


### PR DESCRIPTION
Suite à une refactorisation de la classe AacCsvService liée à l'export de données de qualité de l'eau, certains tests ne passaient plus suite à une non-évolution de mocks de test. Ces mocks ont été mis à jour.

Au passage, si une erreur lors de la communication avec l'espace S3 a lieu pendant l'export, l'erreur est bien gérée.