### PR TITLE
Création d'une commande pour réinitialiser un mot de passe

### DIFF
--- a/app/services/user_service.ts
+++ b/app/services/user_service.ts
@@ -1,6 +1,7 @@
 import User from '#models/user'
 import Territoire from '#models/territoire'
 import Env from '#start/env'
+import { randomBytes } from 'node:crypto'
 
 export type EnvUserSeeds = Array<{
   email: string
@@ -74,5 +75,25 @@ export default class UserService {
         `Assigned ${territoiresIdsToSync.size} territoire(s) to "${email}" based on their ids.`
       )
     }
+  }
+
+  /**
+   * Generates a secure random password, hashes it, and saves it for the given user.
+   * Returns the plain-text generated password so the caller can display it.
+   * The plain-text password is never persisted anywhere in the application.
+   */
+  async resetPassword(email: string): Promise<string> {
+    const user = await User.findBy('email', email.toLowerCase().trim())
+    if (!user) {
+      throw new Error(`User with email "${email}" not found`)
+    }
+
+    // 9 bytes → 12-character base64url string (no padding)
+    const plainPassword = randomBytes(9).toString('base64url')
+
+    user.password = plainPassword
+    await user.save()
+
+    return plainPassword
   }
 }

--- a/commands/user_reset_password.ts
+++ b/commands/user_reset_password.ts
@@ -1,0 +1,27 @@
+import { BaseCommand, args } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import UserService from '#services/user_service'
+
+export default class UserResetPassword extends BaseCommand {
+  static commandName = 'user:reset-password'
+  static description = 'Reset the password of a user and output the generated password'
+
+  static options: CommandOptions = {
+    startApp: true,
+  }
+
+  @args.string({ description: 'Email address of the user' })
+  declare email: string
+
+  async run() {
+    try {
+      const newPassword = await new UserService().resetPassword(this.email)
+      this.logger.success(`Password reset successfully for "${this.email}"`)
+      // Display the generated password directly in stdout so it never ends up in application logs
+      this.logger.info(`New password: ${newPassword}`)
+    } catch (error) {
+      this.logger.error(error instanceof Error ? error.message : 'Failed to reset password')
+      this.exitCode = 1
+    }
+  }
+}

--- a/doc/commandes.md
+++ b/doc/commandes.md
@@ -51,3 +51,15 @@ Assigne un territoire existant à un utilisateur existant (par leurs UUIDs).
 ```bash
 node ace territoire:assign <userId> <territoireId>
 ```
+
+---
+
+## `user:reset-password`
+
+Réinitialise le mot de passe d'un utilisateur et affiche le nouveau mot de passe généré.
+
+```bash
+node ace user:reset-password <email>
+```
+
+Le nouveau mot de passe est affiché directement dans la sortie standard afin de ne jamais apparaître dans les logs applicatifs.


### PR DESCRIPTION
Les utilisateurs perdront forcément leur mot de passe à un moment, et on n'a pas encore de moyen d'envoyer d'e-mails de réinitialisation. 

Cette PR ajoute une commande de réinitialisation qui s'utilise ainsi : 
<img width="780" height="74" alt="image" src="https://github.com/user-attachments/assets/1bbb4884-6863-43c0-8cc0-724d388a7b5b" />
