### PR TITLE
Refactorisation des filtres de la page projets/index

### DIFF
--- a/app/controllers/projects_controller.ts
+++ b/app/controllers/projects_controller.ts
@@ -1,6 +1,5 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
-import Project from '#models/project'
 import Parcelle from '#models/parcelle'
 import Captage from '#models/captage'
 import { ProjectService } from '#services/project_service'
@@ -14,8 +13,6 @@ import {
 } from '#validators/project'
 import { ProjectDto } from '../dto/project_dto.js'
 import { createErrorFlashMessage } from '../helpers/flash_message.js'
-
-const PER_PAGE = 20
 
 @inject()
 export default class ProjectsController {
@@ -44,94 +41,25 @@ export default class ProjectsController {
     const typesActionExclus = typesActionExclusStr ? typesActionExclusStr.split(',') : []
     const statutsExclus = statutsExclusStr ? statutsExclusStr.split(',') : []
 
-    // Total count (unfiltered) — used for the empty-state UI
-    const projetsCount = await Project.query()
-      .where('userId', user.id)
-      .count('* as total')
-      .first()
-      .then((r) => Number(r?.$extras?.total ?? 0))
+    const result = await this.projectService.listProjects(user.id, {
+      recherche,
+      statut,
+      typesActionExclus,
+      statutsExclus,
+      yearFrom,
+      yearTo,
+      page,
+    })
 
-    // All distinct action types for the user (unfiltered) — stable filter options
-    const availableActionTypesRows = await Project.query()
-      .where('userId', user.id)
-      .whereNotNull('actionType')
-      .distinct('actionType')
-      .select('actionType')
-      .orderBy('actionType', 'asc')
-    const availableActionTypes = availableActionTypesRows.map((p) => p.actionType as string)
-
-    // Global year range (unfiltered) — bounds for the year slider
-    const [oldestProject, newestProject] = await Promise.all([
-      Project.query()
-        .where('userId', user.id)
-        .orderBy('createdAt', 'asc')
-        .select('createdAt')
-        .first(),
-      Project.query()
-        .where('userId', user.id)
-        .orderBy('createdAt', 'desc')
-        .select('createdAt')
-        .first(),
-    ])
-    const currentYear = new Date().getFullYear()
-    const availableYearRange = {
-      min: oldestProject?.createdAt.year ?? currentYear,
-      max: newestProject?.createdAt.year ?? currentYear,
-    }
-
-    // Per-status counts using base filters (search + year + type) but no status filter
-    // These power the tab labels so every tab shows its true count given the active filters.
-    const statusCountsQuery = Project.query()
-      .where('userId', user.id)
-      .select('status')
-      .groupBy('status')
-      .count('* as count')
-    if (recherche) statusCountsQuery.whereILike('name', `%${recherche}%`)
-    if (yearFrom !== null)
-      statusCountsQuery.whereRaw('EXTRACT(YEAR FROM created_at) >= ?', [yearFrom])
-    if (yearTo !== null) statusCountsQuery.whereRaw('EXTRACT(YEAR FROM created_at) <= ?', [yearTo])
-    if (typesActionExclus.length > 0) {
-      statusCountsQuery.where((q) => {
-        q.whereNull('actionType').orWhereNotIn('actionType', typesActionExclus)
-      })
-    }
-    const statusCountsRaw = await statusCountsQuery
-    const statusCountsMap: Record<string, number> = {}
-    for (const row of statusCountsRaw) {
-      statusCountsMap[row.status] = Number(row.$extras.count)
-    }
-    const statusCounts = {
-      to_be_started: statusCountsMap['to_be_started'] ?? 0,
-      current: statusCountsMap['current'] ?? 0,
-      completed: statusCountsMap['completed'] ?? 0,
-      abandoned: statusCountsMap['abandoned'] ?? 0,
-    }
-
-    // Main paginated query — all filters applied
-    const mainQuery = Project.query().where('userId', user.id).orderBy('createdAt', 'desc')
-    if (recherche) mainQuery.whereILike('name', `%${recherche}%`)
-    if (yearFrom !== null) mainQuery.whereRaw('EXTRACT(YEAR FROM created_at) >= ?', [yearFrom])
-    if (yearTo !== null) mainQuery.whereRaw('EXTRACT(YEAR FROM created_at) <= ?', [yearTo])
-    if (typesActionExclus.length > 0) {
-      mainQuery.where((q) => {
-        q.whereNull('actionType').orWhereNotIn('actionType', typesActionExclus)
-      })
-    }
-    if (statut !== 'all') {
-      mainQuery.where('status', statut)
-    } else if (statutsExclus.length > 0) {
-      mainQuery.whereNotIn('status', statutsExclus)
-    }
-    const projects = await mainQuery.paginate(page, PER_PAGE)
-    const serializedProjects = ProjectDto.fromPaginator(projects)
+    const serializedProjects = ProjectDto.fromPaginator(result.projects)
 
     return inertia.render('projets/index', {
       projets: serializedProjects.data,
       meta: serializedProjects.meta,
-      projetsCount,
-      availableActionTypes,
-      availableYearRange,
-      statusCounts,
+      projetsCount: result.projetsCount,
+      availableActionTypes: result.availableActionTypes,
+      availableYearRange: result.availableYearRange,
+      statusCounts: result.statusCounts,
       queryString: {
         projetsRecherche: recherche ?? '',
         projetsPage: String(page),

--- a/app/services/project_service.ts
+++ b/app/services/project_service.ts
@@ -1,5 +1,5 @@
 import Project, { ProjectStatus } from '#models/project'
-import { ModelAttributes } from '@adonisjs/lucid/types/model'
+import { ModelAttributes, ModelPaginatorContract } from '@adonisjs/lucid/types/model'
 
 export interface ProjectPayload extends Partial<ModelAttributes<Project>> {
   parcelleIds?: string[]
@@ -7,7 +7,117 @@ export interface ProjectPayload extends Partial<ModelAttributes<Project>> {
   captageIds?: string[]
 }
 
+export interface ProjectIndexFilters {
+  recherche?: string
+  statut: string
+  typesActionExclus: string[]
+  statutsExclus: string[]
+  yearFrom: number | null
+  yearTo: number | null
+  page: number
+}
+
+export interface ProjectIndexResult {
+  projects: ModelPaginatorContract<Project>
+  projetsCount: number
+  availableActionTypes: string[]
+  availableYearRange: { min: number; max: number }
+  statusCounts: {
+    to_be_started: number
+    current: number
+    completed: number
+    abandoned: number
+  }
+}
+
+const PER_PAGE = 20
+
 export class ProjectService {
+  async listProjects(userId: string, filters: ProjectIndexFilters): Promise<ProjectIndexResult> {
+    const { recherche, statut, typesActionExclus, statutsExclus, yearFrom, yearTo, page } = filters
+
+    // Total count (unfiltered) — used for the empty-state UI
+    const projetsCount = await Project.query()
+      .where('userId', userId)
+      .count('* as total')
+      .first()
+      .then((r) => Number(r?.$extras?.total ?? 0))
+
+    // All distinct action types for the user (unfiltered) — stable filter options
+    const availableActionTypesRows = await Project.query()
+      .where('userId', userId)
+      .whereNotNull('actionType')
+      .distinct('actionType')
+      .select('actionType')
+      .orderBy('actionType', 'asc')
+    const availableActionTypes = availableActionTypesRows.map((p) => p.actionType as string)
+
+    // Global year range (unfiltered) — bounds for the year slider
+    const [oldestProject, newestProject] = await Promise.all([
+      Project.query()
+        .where('userId', userId)
+        .orderBy('createdAt', 'asc')
+        .select('createdAt')
+        .first(),
+      Project.query()
+        .where('userId', userId)
+        .orderBy('createdAt', 'desc')
+        .select('createdAt')
+        .first(),
+    ])
+    const currentYear = new Date().getFullYear()
+    const availableYearRange = {
+      min: oldestProject?.createdAt.year ?? currentYear,
+      max: newestProject?.createdAt.year ?? currentYear,
+    }
+
+    // Per-status counts using base filters (search + year + type) but no status filter
+    const statusCountsQuery = Project.query()
+      .where('userId', userId)
+      .select('status')
+      .groupBy('status')
+      .count('* as count')
+    if (recherche) statusCountsQuery.whereILike('name', `%${recherche}%`)
+    if (yearFrom !== null)
+      statusCountsQuery.whereRaw('EXTRACT(YEAR FROM created_at) >= ?', [yearFrom])
+    if (yearTo !== null) statusCountsQuery.whereRaw('EXTRACT(YEAR FROM created_at) <= ?', [yearTo])
+    if (typesActionExclus.length > 0) {
+      statusCountsQuery.where((q) => {
+        q.whereNull('actionType').orWhereNotIn('actionType', typesActionExclus)
+      })
+    }
+    const statusCountsRaw = await statusCountsQuery
+    const statusCountsMap: Record<string, number> = {}
+    for (const row of statusCountsRaw) {
+      statusCountsMap[row.status] = Number(row.$extras.count)
+    }
+    const statusCounts = {
+      to_be_started: statusCountsMap['to_be_started'] ?? 0,
+      current: statusCountsMap['current'] ?? 0,
+      completed: statusCountsMap['completed'] ?? 0,
+      abandoned: statusCountsMap['abandoned'] ?? 0,
+    }
+
+    // Main paginated query — all filters applied
+    const mainQuery = Project.query().where('userId', userId).orderBy('createdAt', 'desc')
+    if (recherche) mainQuery.whereILike('name', `%${recherche}%`)
+    if (yearFrom !== null) mainQuery.whereRaw('EXTRACT(YEAR FROM created_at) >= ?', [yearFrom])
+    if (yearTo !== null) mainQuery.whereRaw('EXTRACT(YEAR FROM created_at) <= ?', [yearTo])
+    if (typesActionExclus.length > 0) {
+      mainQuery.where((q) => {
+        q.whereNull('actionType').orWhereNotIn('actionType', typesActionExclus)
+      })
+    }
+    if (statut !== 'all') {
+      mainQuery.where('status', statut)
+    } else if (statutsExclus.length > 0) {
+      mainQuery.whereNotIn('status', statutsExclus)
+    }
+    const projects = await mainQuery.paginate(page, PER_PAGE)
+
+    return { projects, projetsCount, availableActionTypes, availableYearRange, statusCounts }
+  }
+
   async createProject(payload: ProjectPayload, userId: string) {
     const project = await Project.create({
       name: payload.name,


### PR DESCRIPTION
Cette PR déplace le code métier des filtres de la page projets/index dans le ProjectService, pour que le code soit plus facilement réutilisable/testable au besoin.