### PR TITLE
Ajout d'une étape d'assignation d'AAC à la création d'exploitation

### DIFF
--- a/app/controllers/exploitations_controller.ts
+++ b/app/controllers/exploitations_controller.ts
@@ -94,7 +94,8 @@ export default class ExploitationsController {
       ...EVENTS.CREATE_FORM,
     })
 
-    const page = request.input('territoiresPage', 1)
+    const pageInput = request.input('territoiresPage', '1')
+    const page = Math.max(1, Number.parseInt(String(pageInput), 10) || 1)
     const paginatedTerritoires = await this.territoireService.getTerritoiresForUser(user.id, page)
 
     return inertia.render('exploitations/creation', {
@@ -122,7 +123,8 @@ export default class ExploitationsController {
       .where({ id: params.id })
       .firstOrFail()
 
-    const page = request.input('territoiresPage', 1)
+    const pageInput = request.input('territoiresPage', '1')
+    const page = Math.max(1, Number.parseInt(String(pageInput), 10) || 1)
     const paginatedTerritoires = await this.territoireService.getTerritoiresForUser(user.id, page)
 
     return inertia.render('exploitations/edition', {
@@ -237,6 +239,21 @@ export default class ExploitationsController {
       createExploitationValidator
     )
 
+    const userTerritoireIds = user.territoires.map((t) => t.id)
+
+    // Check if the current user can assign these territoires to the exploitation
+    for (const territoireId of territoireIds) {
+      if (!userTerritoireIds.includes(territoireId)) {
+        createErrorFlashMessage(
+          session,
+          "L'un des territoires sélectionnés n'existe pas ou ne vous appartient pas.",
+          undefined,
+          'territoire'
+        )
+        return response.redirect().back()
+      }
+    }
+
     const rawPrimaryContact = contacts?.find((c) => c.isPrimaryContact !== false)
     const primaryContact = rawPrimaryContact
       ? { ...rawPrimaryContact, id: rawPrimaryContact.id ?? undefined }
@@ -284,6 +301,23 @@ export default class ExploitationsController {
 
     if (await bouncer.with(ExploitationPolicy).denies('write', exploitation)) {
       return response.forbidden("Impossible de mettre à jour l'exploitation")
+    }
+
+    await user.loadOnce('territoires')
+
+    const userTerritoireIds = user.territoires.map((t) => t.id)
+
+    // Check if the current user can assign these territoires to the exploitation
+    for (const territoireId of territoireIds) {
+      if (!userTerritoireIds.includes(territoireId)) {
+        createErrorFlashMessage(
+          session,
+          "L'un des territoires sélectionnés n'existe pas ou ne vous appartient pas.",
+          undefined,
+          'territoire'
+        )
+        return response.redirect().back()
+      }
     }
 
     const rawPrimaryContact = contacts?.find((c) => c.isPrimaryContact !== false)

--- a/app/controllers/exploitations_controller.ts
+++ b/app/controllers/exploitations_controller.ts
@@ -21,6 +21,8 @@ import { ParcelleService } from '#services/parcelle_service'
 import { ParcelleCsvService } from '#services/parcelle_csv_service'
 import ExploitationPolicy from '#policies/exploitation_policy'
 import { ExploitationCsvService } from '#services/exploitation_csv_service'
+import { TerritoireDto } from '../dto/territoire_dto.js'
+import { TerritoireService } from '#services/territoire_service'
 
 // Définition centralisée des noms d'événements pour ce contrôleur
 const EVENTS = {
@@ -46,7 +48,8 @@ export default class ExploitationsController {
     public eventLogger: EventLoggerService,
     public parcelleService: ParcelleService,
     public parcelleCsvService: ParcelleCsvService,
-    public exploitationCsvService: ExploitationCsvService
+    public exploitationCsvService: ExploitationCsvService,
+    public territoireService: TerritoireService
   ) {}
 
   async index({ request, inertia, auth }: HttpContext) {
@@ -84,21 +87,25 @@ export default class ExploitationsController {
     })
   }
 
-  async create({ inertia, auth }: HttpContext) {
+  async create({ inertia, request, auth }: HttpContext) {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
       ...EVENTS.CREATE_FORM,
     })
 
+    const page = request.input('territoiresPage', 1)
+    const paginatedTerritoires = await this.territoireService.getTerritoiresForUser(user.id, page)
+
     return inertia.render('exploitations/creation', {
       exploitationTags: ExploitationTagDto.fromArray(
         await this.exploitationTagService.getExploitationTags()
       ),
+      territoires: TerritoireDto.fromPaginator(paginatedTerritoires),
     })
   }
 
-  async getForEdition({ params, inertia, auth }: HttpContext) {
+  async getForEdition({ params, inertia, request, auth }: HttpContext) {
     const user = auth.getUserOrFail()
     this.eventLogger.logEvent({
       userId: user.id,
@@ -111,14 +118,19 @@ export default class ExploitationsController {
       .preload('user')
       .preload('contacts')
       .preload('tags')
+      .preload('territoires')
       .where({ id: params.id })
       .firstOrFail()
+
+    const page = request.input('territoiresPage', 1)
+    const paginatedTerritoires = await this.territoireService.getTerritoiresForUser(user.id, page)
 
     return inertia.render('exploitations/edition', {
       exploitation: ExploitationDto.fromModel(exploitation),
       exploitationTags: ExploitationTagDto.fromArray(
         await this.exploitationTagService.getExploitationTags()
       ),
+      territoires: TerritoireDto.fromPaginator(paginatedTerritoires),
     })
   }
 
@@ -221,7 +233,9 @@ export default class ExploitationsController {
 
     await user.loadOnce('territoires')
 
-    const { contacts, tags, ...payload } = await request.validateUsing(createExploitationValidator)
+    const { contacts, tags, territoireIds, ...payload } = await request.validateUsing(
+      createExploitationValidator
+    )
 
     const rawPrimaryContact = contacts?.find((c) => c.isPrimaryContact !== false)
     const primaryContact = rawPrimaryContact
@@ -233,7 +247,7 @@ export default class ExploitationsController {
 
     const exploitation = await this.exploitationService.createExploitationWithContact(
       { ...payload, userId: user.id },
-      user.territoires.map((t) => t.id),
+      territoireIds,
       primaryContact,
       secondaryContacts
     )
@@ -259,7 +273,7 @@ export default class ExploitationsController {
       ...EVENTS.UPDATE_SUBMITTED,
     })
 
-    const { contacts, tags, params, ...payload } = await request.validateUsing(
+    const { contacts, tags, params, territoireIds, ...payload } = await request.validateUsing(
       updateExploitationValidator
     )
 
@@ -290,6 +304,8 @@ export default class ExploitationsController {
     if (Array.isArray(tags)) {
       await updatedExploitation.related('tags').sync(tags.map((tag) => tag.id))
     }
+
+    await updatedExploitation.related('territoires').sync(territoireIds)
 
     this.eventLogger.logEvent({
       userId: user.id,

--- a/app/dto/exploitation_dto.ts
+++ b/app/dto/exploitation_dto.ts
@@ -3,6 +3,7 @@ import { ExploitationJson, PaginatedJson } from '../../types/models.js'
 import { ModelPaginatorContract } from '@adonisjs/lucid/types/model'
 import { LogEntryDto } from './log_entry_dto.js'
 import { ParcelleDto } from './parcelle_dto.js'
+import { TerritoireDto } from './territoire_dto.js'
 
 export class ExploitationDto {
   static fromModel(exploitation: Exploitation): ExploitationJson {
@@ -24,6 +25,9 @@ export class ExploitationDto {
       tags: exploitation.tags,
       logEntries: exploitation.logEntries?.map((logEntry) => LogEntryDto.fromModel(logEntry)),
       parcelles: exploitation.parcelles?.map((parcelle) => ParcelleDto.fromModel(parcelle)),
+      territoires: exploitation.territoires?.map((territoire) =>
+        TerritoireDto.fromModel(territoire)
+      ),
     }
   }
 

--- a/app/dto/territoire_dto.ts
+++ b/app/dto/territoire_dto.ts
@@ -1,0 +1,30 @@
+import { TerritoireJson, PaginatedJson } from '../../types/models.js'
+import Territoire from '#models/territoire'
+import { ModelPaginatorContract } from '@adonisjs/lucid/types/model'
+
+export class TerritoireDto {
+  static fromModel(territoire: Territoire): TerritoireJson {
+    return {
+      id: territoire.id,
+      name: territoire.name,
+      code: territoire.code,
+    }
+  }
+
+  static fromArray(territoires: Territoire[]): TerritoireJson[] {
+    return territoires.map(TerritoireDto.fromModel)
+  }
+
+  static fromPaginator(
+    paginatedTerritoires: ModelPaginatorContract<Territoire>
+  ): PaginatedJson<TerritoireJson> {
+    const transformedData = (paginatedTerritoires.toJSON().data as Territoire[]).map(
+      TerritoireDto.fromModel
+    )
+
+    return {
+      meta: paginatedTerritoires.getMeta(),
+      data: transformedData,
+    }
+  }
+}

--- a/app/services/territoire_service.ts
+++ b/app/services/territoire_service.ts
@@ -12,4 +12,22 @@ export class TerritoireService {
       name: trimmedName,
     })
   }
+
+  async getTerritoiresForUser(userId: string, page: number = 1, perPage: number = 20) {
+    return (
+      Territoire.query()
+        .whereHas('users', (usersQuery) => {
+          usersQuery.where('users.id', userId)
+        })
+        /*
+          Order by code as integer if it exists, otherwise by name.
+          This ensures that territoires with numeric codes are sorted in natural numeric order,
+          while those without codes are sorted alphabetically by name and appear after those with codes.
+         */
+        .orderByRaw(
+          'CASE WHEN code IS NULL THEN 1 ELSE 0 END, CASE WHEN code IS NOT NULL THEN code::int END ASC NULLS LAST, name ASC'
+        )
+        .paginate(page, perPage)
+    )
+  }
 }

--- a/app/services/territoire_service.ts
+++ b/app/services/territoire_service.ts
@@ -25,7 +25,9 @@ export class TerritoireService {
           while those without codes are sorted alphabetically by name and appear after those with codes.
          */
         .orderByRaw(
-          'CASE WHEN code IS NULL THEN 1 ELSE 0 END, CASE WHEN code IS NOT NULL THEN code::int END ASC NULLS LAST, name ASC'
+          `CASE WHEN code ~ '^[0-9]+$' THEN code::int END ASC NULLS LAST,
+            code ASC NULLS LAST,
+            name ASC`
         )
         .paginate(page, perPage)
     )

--- a/app/validators/create_exploitation.ts
+++ b/app/validators/create_exploitation.ts
@@ -52,6 +52,7 @@ const exploitationFormFieldsValidator = {
     .array(vine.object({ id: vine.number().positive(), name: vine.string() }))
     .optional()
     .nullable(),
+  territoireIds: vine.array(vine.string().uuid()).minLength(1),
 }
 
 export const createExploitationValidator = vine.compile(

--- a/inertia/components/exploitations/form/exploitation-form.tsx
+++ b/inertia/components/exploitations/form/exploitation-form.tsx
@@ -4,9 +4,16 @@ import { Stepper } from '@codegouvfr/react-dsfr/Stepper'
 import ExploitationIdentification from '~/components/exploitations/form/exploitation-identification'
 import ExploitationLocalisation from '~/components/exploitations/form/exploitation-localisation'
 import ExploitationContact from '~/components/exploitations/form/exploitation-contact'
+import ExploitationTerritoires from '~/components/exploitations/form/exploitation-territoires'
 import { checkSiretExists } from '~/lib/exploitations'
 
-import type { ContactJson, ExploitationJson, ExploitationTagJson } from '../../../../types/models'
+import type {
+  ContactJson,
+  ExploitationJson,
+  ExploitationTagJson,
+  PaginatedJson,
+  TerritoireJson,
+} from '#types/models'
 import { SetDataAction } from '@inertiajs/react'
 import ExploitationOtherContacts from '../exploitation-other-contacts'
 import SectionCard from '~/ui/SectionCard'
@@ -22,6 +29,7 @@ interface ExploitationsFormProps {
   setError?: (value: { [key: string]: any }) => void
   onSubmit: () => void
   exploitationTags: ExploitationTagJson[]
+  territoires: PaginatedJson<TerritoireJson>
   isEdition?: boolean
 }
 
@@ -41,6 +49,7 @@ export type ExploitationFormValues = {
   notes: string | null
   contacts: ContactJson[]
   tags: ExploitationTagJson[]
+  territoireIds: string[]
 }
 
 // Function to get default values for the exploitation form. Can take an optional exploitation to prefill the form, in edition mode.
@@ -63,10 +72,11 @@ export function getExploitationFormDefaultValues(
     notes: exploitation?.notes || null,
     contacts: exploitation?.contacts || [],
     tags: exploitation?.tags || [],
+    territoireIds: exploitation?.territoires?.map((t) => t.id) || [],
   }
 }
 
-const steps = ['Type d’exploitation', 'Localisation', 'Contact']
+const steps = ["Type d'exploitation", 'Localisation', 'AAC', 'Contact']
 
 export default function ExploitationsForm({
   step,
@@ -78,10 +88,12 @@ export default function ExploitationsForm({
   setError,
   onSubmit,
   exploitationTags,
+  territoires,
   isEdition = false,
 }: ExploitationsFormProps) {
-  // Name is the only required field, so we can enable the next button as soon as it's filled
-  const isNextStepDisabled = step === 1 && !exploitation.name
+  // Name is required for step 1; at least one territoire is required for step 3
+  const isNextStepDisabled =
+    (step === 1 && !exploitation.name) || (step === 3 && exploitation.territoireIds.length === 0)
   async function handleSteps() {
     if (step === 1) {
       if (exploitation?.siret) {
@@ -100,11 +112,11 @@ export default function ExploitationsForm({
       setError?.({})
     }
 
-    if (step === 3) {
+    if (step === 4) {
       onSubmit()
     }
 
-    if (step !== 3) {
+    if (step !== 4) {
       visitStep(step + 1)
     }
   }
@@ -134,6 +146,13 @@ export default function ExploitationsForm({
         <ExploitationLocalisation exploitation={exploitation} setExploitation={setExploitation} />
       )}
       {step === 3 && (
+        <ExploitationTerritoires
+          exploitation={exploitation}
+          setExploitation={setExploitation}
+          territoires={territoires}
+        />
+      )}
+      {step === 4 && (
         <div className="flex flex-col gap-4">
           <SectionCard title="Contact principal" icon="fr-icon-user-star-line">
             <Alert
@@ -178,7 +197,7 @@ export default function ExploitationsForm({
           disabled={isNextStepDisabled}
           onClick={handleSteps}
         >
-          {step === 3
+          {step === 4
             ? isEdition
               ? 'Valider les modifications'
               : 'Créer l’exploitation'

--- a/inertia/components/exploitations/form/exploitation-territoires.tsx
+++ b/inertia/components/exploitations/form/exploitation-territoires.tsx
@@ -21,18 +21,6 @@ export default function ExploitationTerritoires({
 }: ExploitationTerritoiresProps) {
   const selectedIds = exploitation.territoireIds ?? []
 
-  // const sortedTerritoires = [...territoires.data].sort((a, b) => {
-  //   if (a.code && b.code) {
-  //     const aNum = Number(a.code)
-  //     const bNum = Number(b.code)
-  //     if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) return aNum - bNum
-  //     return a.code.localeCompare(b.code)
-  //   }
-  //   if (a.code) return -1
-  //   if (b.code) return 1
-  //   return (a.name ?? '').localeCompare(b.name ?? '')
-  // })
-
   function handleChange(id: string, checked: boolean) {
     const next = checked ? [...selectedIds, id] : selectedIds.filter((t: string) => t !== id)
     setExploitation('territoireIds', next)
@@ -67,22 +55,25 @@ export default function ExploitationTerritoires({
             />
           )
         })}
-        <Pagination
-          count={territoires.meta.lastPage}
-          defaultPage={territoires.meta.currentPage}
-          showFirstLast={true}
-          getPageLinkProps={(pageNumber) => ({
-            href: '#',
-            onClick: (e: React.MouseEvent) => {
-              e.preventDefault()
-              router.reload({
-                only: ['territoires'],
-                data: { territoiresPage: String(pageNumber) },
-                replace: true,
-              })
-            },
-          })}
-        />
+
+        {territoires.meta.lastPage > 1 && (
+          <Pagination
+            count={territoires.meta.lastPage}
+            defaultPage={territoires.meta.currentPage}
+            showFirstLast={true}
+            getPageLinkProps={(pageNumber) => ({
+              href: '#',
+              onClick: (e: React.MouseEvent) => {
+                e.preventDefault()
+                router.reload({
+                  only: ['territoires'],
+                  data: { territoiresPage: String(pageNumber) },
+                  replace: true,
+                })
+              },
+            })}
+          />
+        )}
       </div>
     </div>
   )

--- a/inertia/components/exploitations/form/exploitation-territoires.tsx
+++ b/inertia/components/exploitations/form/exploitation-territoires.tsx
@@ -1,0 +1,89 @@
+import { Alert } from '@codegouvfr/react-dsfr/Alert'
+
+import type { TerritoireJson } from '~/../../types/models'
+import { ExploitationFormValues } from '~/components/exploitations/form/exploitation-form'
+import { router, SetDataAction } from '@inertiajs/react'
+import CheckboxCard from '~/ui/CheckboxCard'
+import React from 'react'
+import { Pagination } from '@codegouvfr/react-dsfr/Pagination'
+import type { PaginatedJson } from '#types/models'
+
+interface ExploitationTerritoiresProps {
+  exploitation: ExploitationFormValues
+  setExploitation: SetDataAction<ExploitationFormValues>
+  territoires: PaginatedJson<TerritoireJson>
+}
+
+export default function ExploitationTerritoires({
+  exploitation,
+  setExploitation,
+  territoires,
+}: ExploitationTerritoiresProps) {
+  const selectedIds = exploitation.territoireIds ?? []
+
+  // const sortedTerritoires = [...territoires.data].sort((a, b) => {
+  //   if (a.code && b.code) {
+  //     const aNum = Number(a.code)
+  //     const bNum = Number(b.code)
+  //     if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) return aNum - bNum
+  //     return a.code.localeCompare(b.code)
+  //   }
+  //   if (a.code) return -1
+  //   if (b.code) return 1
+  //   return (a.name ?? '').localeCompare(b.name ?? '')
+  // })
+
+  function handleChange(id: string, checked: boolean) {
+    const next = checked ? [...selectedIds, id] : selectedIds.filter((t: string) => t !== id)
+    setExploitation('territoireIds', next)
+  }
+
+  return (
+    <div className="fr-mt-4w">
+      <Alert
+        className="fr-mb-4w"
+        severity="info"
+        small
+        description="Sélectionnez au moins une AAC pour associer cette exploitation. Seuls les AAC auxquelles vous avez accès sont listées."
+      />
+      <div className="fr-mb-4w grid gap-3">
+        {territoires.data.map((territoire) => {
+          let title = territoire.name
+
+          if (!title && territoire.code) {
+            title = `AAC ${territoire.code}`
+          } else if (!title) {
+            title = `Territoire non-SANDRE sans nom (${territoire.id})`
+          }
+
+          return (
+            <CheckboxCard
+              key={territoire.id}
+              value={territoire.id}
+              title={title}
+              subtitle={territoire.code ? `Code SANDRE : ${territoire.code}` : 'Pas de code SANDRE'}
+              isSelected={selectedIds.includes(territoire.id)}
+              onCheck={() => handleChange(territoire.id, !selectedIds.includes(territoire.id))}
+            />
+          )
+        })}
+        <Pagination
+          count={territoires.meta.lastPage}
+          defaultPage={territoires.meta.currentPage}
+          showFirstLast={true}
+          getPageLinkProps={(pageNumber) => ({
+            href: '#',
+            onClick: (e: React.MouseEvent) => {
+              e.preventDefault()
+              router.reload({
+                only: ['territoires'],
+                data: { territoiresPage: String(pageNumber) },
+                replace: true,
+              })
+            },
+          })}
+        />
+      </div>
+    </div>
+  )
+}

--- a/inertia/pages/exploitations/creation.tsx
+++ b/inertia/pages/exploitations/creation.tsx
@@ -13,6 +13,7 @@ import ExploitationsController from '#controllers/exploitations_controller'
 
 export default function ExploitationsCreationPage({
   exploitationTags,
+  territoires,
 }: InferPageProps<ExploitationsController, 'create'>) {
   const { url } = usePage()
   const urlParams = new URLSearchParams(url.split('?')[1] || '')
@@ -62,6 +63,7 @@ export default function ExploitationsCreationPage({
         setError={setError}
         onSubmit={handleSubmit}
         exploitationTags={exploitationTags}
+        territoires={territoires}
       />
     </Layout>
   )

--- a/inertia/pages/exploitations/edition.tsx
+++ b/inertia/pages/exploitations/edition.tsx
@@ -14,6 +14,7 @@ import { InferPageProps } from '@adonisjs/inertia/types'
 export default function ExploitationEditionPage({
   exploitation: initialExploitation,
   exploitationTags,
+  territoires,
 }: InferPageProps<ExploitationsController, 'getForEdition'>) {
   const { url } = usePage()
   const urlParams = new URLSearchParams(url.split('?')[1] || '')
@@ -71,6 +72,7 @@ export default function ExploitationEditionPage({
         setError={setError}
         onSubmit={handleSubmit}
         exploitationTags={exploitationTags}
+        territoires={territoires}
       />
     </Layout>
   )

--- a/tests/functional/exploitation/exploitation_create.spec.ts
+++ b/tests/functional/exploitation/exploitation_create.spec.ts
@@ -12,6 +12,7 @@ test.group('Exploitation - Create Resource', (group) => {
     const fakeExploitation = await ExploitationFactory.make()
     const exploitationPayload = {
       ...fakeExploitation.toJSON(),
+      territoireIds: [user.territoires[0].id],
       location: { x: 2.3522, y: 48.8566 },
     }
 
@@ -33,6 +34,7 @@ test.group('Exploitation - Create Resource', (group) => {
     const exploitationPayload = {
       ...fakeExploitation.toJSON(),
       location: { x: 2.3522, y: 48.8566 },
+      territoireIds: [user.territoires[0].id],
       contacts: [
         {
           firstName: 'Jane',

--- a/tests/functional/exploitation/exploitation_update.spec.ts
+++ b/tests/functional/exploitation/exploitation_update.spec.ts
@@ -19,6 +19,7 @@ test.group('Exploitation - Update Resource', (group) => {
     const exploitationPayload = {
       ...existingExploitation.toJSON(),
       location: { x: 2.3522, y: 48.8566 },
+      territoireIds: [territoire.id],
       name: newName,
     }
 
@@ -46,6 +47,7 @@ test.group('Exploitation - Update Resource', (group) => {
     const exploitationPayload = {
       ...existingExploitation.toJSON(),
       location: { x: 2.3522, y: 48.8566 },
+      territoireIds: [territoire.id],
       contacts: [{ firstName: newContactName }],
     }
 
@@ -75,6 +77,7 @@ test.group('Exploitation - Update Resource', (group) => {
     const exploitationPayload = {
       ...fakeExploitation.toJSON(),
       location: { x: 2.3522, y: 48.8566 },
+      territoireIds: [territoire.id],
       contacts: [{ lastName: 'Doe' }],
     }
 
@@ -95,6 +98,7 @@ test.group('Exploitation - Update Resource', (group) => {
     const exploitationPayload = {
       name: 'Some Name',
       location: { x: 2.3522, y: 48.8566 },
+      territoireIds: [user.territoires[0].id],
       contacts: [{ lastName: 'Doe' }],
     }
     const response = await client
@@ -122,6 +126,7 @@ test.group('Exploitation - Update Resource', (group) => {
     const exploitationPayload = {
       ...existingExploitation.toJSON(),
       location: { x: 2.3522, y: 48.8566 },
+      territoireIds: [territoire.id],
       name: newName,
     }
 

--- a/types/models.ts
+++ b/types/models.ts
@@ -27,6 +27,12 @@ export type ExploitationTagJson = {
   group: string
 }
 
+export type TerritoireJson = {
+  id: string
+  name: string | null
+  code: string | null
+}
+
 export type LogEntryTagJson = {
   id: number
   name: string
@@ -121,6 +127,7 @@ export type ExploitationJson = {
   tags?: ExploitationTagJson[] | null
   logEntries?: LogEntryJson[] | null
   parcelles?: ParcelleJson[] | null
+  territoires?: TerritoireJson[] | null
 }
 
 export type AacSummaryJson = {


### PR DESCRIPTION
Les exploitations sont associées à des territoires (AAC) afin de limiter qui peut avoir accès aux informations. Jusque là, à la création d'exploitation, on l'associait à l'ensemble des territoires de l'utilisateur qui la créé. 

Cette PR ajoute une étape dans le formulaire de création d'exploitation pour cibler plus finement à quel(s) territoire(s) l'assigner. La très grande majorité des utilisateurs auront un nombre limité de territoires (1-10), mais l'utilisateur administrateur utilisé pour les démos est dans tous les territoires, un système de pagination a donc été mis en place. 

<img width="1264" height="1027" alt="image" src="https://github.com/user-attachments/assets/5bf0238c-bde6-4e6f-a524-ed3c6c244488" />


Closes #438 