### PR TITLE
Suppression des erreurs silencieuses liées aux flashMessages en production

### DIFF
--- a/config/inertia.ts
+++ b/config/inertia.ts
@@ -16,7 +16,7 @@ const inertiaConfig = defineConfig({
     user: (ctx) => ctx.inertia.always(() => ctx.auth?.user as User),
     flashMessages: (ctx) =>
       ctx.inertia.always(
-        () => ctx.session.flashMessages.toJSON() as Record<FlashMessageType, FlashMessageValue>
+        () => ctx.session?.flashMessages?.toJSON() as Record<FlashMessageType, FlashMessageValue>
       ),
   },
 


### PR DESCRIPTION
Les logs en mode production sont pollués par la même erreur à chaque rendu de page à cause d'un accès à un objet session qui peut être `undefined`.
<img width="1447" height="79" alt="image" src="https://github.com/user-attachments/assets/689d8aea-78c9-4e39-980f-f62236d157ad" />

Cette PR résout le problème en remplaçant cet accès par un accès conditionnel, pour envoyer `undefined` à la place de lancer une erreur. Le front s'attend à recevoir possiblement `undefined` dans la gestion des flashMessages, il n'y a donc pas de problème de ce côté là.