### PR TITLE
Création de la page "Mes territoires"

### DIFF
--- a/app/controllers/territoires_controller.ts
+++ b/app/controllers/territoires_controller.ts
@@ -1,24 +1,28 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
 import { AacService } from '#services/aac_service'
+import { TerritoireService } from '#services/territoire_service'
 import { AacDto, type AacSummaryJson } from '../dto/aac_dto.js'
 
 const PER_PAGE = 20
 
 @inject()
 export default class TerritoiresController {
-  constructor(public aacService: AacService) {}
+  constructor(
+    public aacService: AacService,
+    public territoireService: TerritoireService
+  ) {}
 
   async index({ auth, request, inertia }: HttpContext) {
     const user = auth.getUserOrFail()
     const pageInput = request.input('territoiresPage') || request.input('page') || '1'
     const page = Math.max(1, Number.parseInt(pageInput, 10) || 1)
 
-    const territoiresPaginator = await user
-      .related('territoires')
-      .query()
-      .orderByRaw('name IS NULL, name ASC')
-      .paginate(page, PER_PAGE)
+    const territoiresPaginator = await this.territoireService.getTerritoiresForUser(
+      user.id,
+      page,
+      PER_PAGE
+    )
 
     const rawTerritoires = territoiresPaginator.toJSON().data as any[]
 

--- a/app/controllers/territoires_controller.ts
+++ b/app/controllers/territoires_controller.ts
@@ -1,7 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
 import { AacService } from '#services/aac_service'
-import type { AacJson } from '../../types/aac.js'
+import { AacDto, type AacSummaryJson } from '../dto/aac_dto.js'
 
 const PER_PAGE = 20
 
@@ -22,9 +22,10 @@ export default class TerritoiresController {
 
     const rawTerritoires = territoiresPaginator.toJSON().data as any[]
 
-    // Fetch AAC data (surface, nb_communes) for territoires that have a code
+    // Fetch AAC data for territoires that have a code (fields live in the
+    // Parquet dataset, not on the `territoires` table).
     const aacCodes = rawTerritoires.map((t: any) => t.code).filter(Boolean) as string[]
-    let aacByCode: Record<string, { surface: number; nb_communes: number }> = {}
+    let aacByCode: Record<string, AacSummaryJson> = {}
     if (aacCodes.length > 0) {
       const { data } = await this.aacService.getAll(
         1,
@@ -34,12 +35,8 @@ export default class TerritoiresController {
         aacCodes
       )
       for (const row of data) {
-        const code = row.code as string
-        const communes = row.communes as AacJson['communes'] | null
-        aacByCode[code] = {
-          surface: row.surface as number,
-          nb_communes: communes?.nb_communes ?? 0,
-        }
+        const summary = AacDto.fromRawSummary(row)
+        aacByCode[summary.code] = summary
       }
     }
 
@@ -52,13 +49,13 @@ export default class TerritoiresController {
         typeLabel: territoire.code ? 'AAC Sandre' : 'Autre territoire',
         aacHref: territoire.code ? `/aac/${territoire.code}` : null,
         surface: aac?.surface ?? null,
-        nb_captages_actifs: territoire.nb_captages_actifs ?? null,
+        nb_captages_actifs: aac?.nb_captages_actifs ?? null,
         nb_communes: aac?.nb_communes ?? null,
-        date_maj: territoire.date_maj ?? null,
-        date_creation: territoire.date_creation ?? null,
-        bbox: territoire.bbox ?? null,
-        communes: territoire.communes ?? null,
-        nb_parcelles: territoire.nb_parcelles ?? null,
+        date_maj: aac?.date_maj ?? null,
+        date_creation: aac?.date_creation ?? null,
+        bbox: aac?.bbox ?? null,
+        communes: aac?.communes ?? null,
+        nb_parcelles: aac?.nb_parcelles ?? null,
       }
     })
 

--- a/app/controllers/territoires_controller.ts
+++ b/app/controllers/territoires_controller.ts
@@ -1,0 +1,70 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { AacService } from '#services/aac_service'
+import type { AacJson } from '../../types/aac.js'
+
+const PER_PAGE = 20
+
+@inject()
+export default class TerritoiresController {
+  constructor(public aacService: AacService) {}
+
+  async index({ auth, request, inertia }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const pageInput = request.input('territoiresPage') || request.input('page') || '1'
+    const page = Math.max(1, Number.parseInt(pageInput, 10) || 1)
+
+    const territoiresPaginator = await user
+      .related('territoires')
+      .query()
+      .orderByRaw('name IS NULL, name ASC')
+      .paginate(page, PER_PAGE)
+
+    const rawTerritoires = territoiresPaginator.toJSON().data as any[]
+
+    // Fetch AAC data (surface, nb_communes) for territoires that have a code
+    const aacCodes = rawTerritoires.map((t: any) => t.code).filter(Boolean) as string[]
+    let aacByCode: Record<string, { surface: number; nb_communes: number }> = {}
+    if (aacCodes.length > 0) {
+      const { data } = await this.aacService.getAll(
+        1,
+        aacCodes.length,
+        undefined,
+        undefined,
+        aacCodes
+      )
+      for (const row of data) {
+        const code = row.code as string
+        const communes = row.communes as AacJson['communes'] | null
+        aacByCode[code] = {
+          surface: row.surface as number,
+          nb_communes: communes?.nb_communes ?? 0,
+        }
+      }
+    }
+
+    const territoires = rawTerritoires.map((territoire: any) => {
+      const aac = territoire.code ? aacByCode[territoire.code] : null
+      return {
+        id: territoire.id,
+        nom: territoire.nom ?? territoire.name ?? 'Territoire sans nom',
+        code: territoire.code,
+        typeLabel: territoire.code ? 'AAC Sandre' : 'Autre territoire',
+        aacHref: territoire.code ? `/aac/${territoire.code}` : null,
+        surface: aac?.surface ?? null,
+        nb_captages_actifs: territoire.nb_captages_actifs ?? null,
+        nb_communes: aac?.nb_communes ?? null,
+        date_maj: territoire.date_maj ?? null,
+        date_creation: territoire.date_creation ?? null,
+        bbox: territoire.bbox ?? null,
+        communes: territoire.communes ?? null,
+        nb_parcelles: territoire.nb_parcelles ?? null,
+      }
+    })
+
+    return inertia.render('territoires/index', {
+      territoires,
+      meta: territoiresPaginator.getMeta(),
+    })
+  }
+}

--- a/app/dto/territoire_dto.ts
+++ b/app/dto/territoire_dto.ts
@@ -3,11 +3,23 @@ import Territoire from '#models/territoire'
 import { ModelPaginatorContract } from '@adonisjs/lucid/types/model'
 
 export class TerritoireDto {
-  static fromModel(territoire: Territoire): TerritoireJson {
+  static fromModel(territoire: Territoire | any): TerritoireJson {
+    // Cast to any to access properties that may come from specific queries
+    const ter = territoire as any
     return {
-      id: territoire.id,
-      name: territoire.name,
-      code: territoire.code,
+      id: ter.id,
+      nom: ter.nom ?? ter.name ?? 'Territoire sans nom',
+      code: ter.code,
+      typeLabel: ter.code ? 'AAC Sandre' : 'Autre territoire',
+      aacHref: ter.code ? `/aac/${ter.code}` : null,
+      surface: ter.surface ?? null,
+      nb_captages_actifs: ter.nb_captages_actifs ?? null,
+      nb_communes: ter.nb_communes ?? null,
+      date_maj: ter.date_maj ?? null,
+      date_creation: ter.date_creation ?? null,
+      bbox: ter.bbox ?? null,
+      communes: ter.communes ?? null,
+      nb_parcelles: ter.nb_parcelles ?? null,
     }
   }
 

--- a/inertia/components/exploitations/form/exploitation-territoires.tsx
+++ b/inertia/components/exploitations/form/exploitation-territoires.tsx
@@ -36,7 +36,7 @@ export default function ExploitationTerritoires({
       />
       <div className="fr-mb-4w grid gap-3">
         {territoires.data.map((territoire) => {
-          let title = territoire.name
+          let title = territoire.nom
 
           if (!title && territoire.code) {
             title = `AAC ${territoire.code}`

--- a/inertia/pages/territoires/index.tsx
+++ b/inertia/pages/territoires/index.tsx
@@ -37,7 +37,7 @@ export default function TerritoiresIndex({
               {territoires.map((territoire: TerritoireJson, index: number) => {
                 return (
                   <ListItem
-                    key={territoire.code}
+                    key={territoire.id}
                     title={territoire.nom}
                     linkProps={territoire.aacHref ? { href: territoire.aacHref } : undefined}
                     priority={index % 2 === 0 ? 'primary' : 'secondary'}
@@ -60,7 +60,7 @@ export default function TerritoiresIndex({
                         ? [
                             {
                               content: `${territoire.nb_captages_actifs} captage${territoire.nb_captages_actifs > 1 ? 's' : ''} actif${territoire.nb_captages_actifs > 1 ? 's' : ''}`,
-                              iconId: 'fr-icon-water-line',
+                              iconId: 'fr-icon-drop-line',
                             },
                           ]
                         : []),

--- a/inertia/pages/territoires/index.tsx
+++ b/inertia/pages/territoires/index.tsx
@@ -1,0 +1,97 @@
+import { Head } from '@inertiajs/react'
+import { InferPageProps } from '@adonisjs/inertia/types'
+import TerritoiresController from '#controllers/territoires_controller'
+import { fr } from '@codegouvfr/react-dsfr'
+import LocationFrance from '@codegouvfr/react-dsfr/picto/LocationFrance'
+import Layout from '~/ui/layouts/layout'
+import EmptyPlaceholder from '~/ui/EmptyPlaceholder'
+import { Pagination } from '@codegouvfr/react-dsfr/Pagination'
+import ListItem from '~/ui/ListItem'
+import type { TerritoireJson } from '#types/models'
+
+export default function TerritoiresIndex({
+  territoires,
+  meta,
+}: InferPageProps<TerritoiresController, 'index'>) {
+  return (
+    <Layout>
+      <Head title="Mes territoires" />
+      <div
+        className="fr-p-2w"
+        style={{ backgroundColor: fr.colors.decisions.background.alt.blueFrance.default }}
+      >
+        <div className="fr-container">
+          <div className="fr-h6 fr-mb-0">Territoires associés à votre compte</div>
+        </div>
+      </div>
+
+      <div className="fr-container flex flex-col gap-4 fr-mt-4w fr-mb-8w">
+        {territoires.length === 0 ? (
+          <EmptyPlaceholder
+            label="Aucun territoire associé à votre compte"
+            pictogram={LocationFrance}
+          />
+        ) : (
+          <>
+            <div className="flex flex-col gap-2">
+              {territoires.map((territoire: TerritoireJson, index: number) => {
+                return (
+                  <ListItem
+                    key={territoire.code}
+                    title={territoire.nom}
+                    linkProps={territoire.aacHref ? { href: territoire.aacHref } : undefined}
+                    priority={index % 2 === 0 ? 'primary' : 'secondary'}
+                    metas={[
+                      {
+                        content: territoire.code
+                          ? `Code SANDRE : ${territoire.code}`
+                          : 'Territoire non identifié au SANDRE',
+                        iconId: territoire.code ? 'fr-icon-hashtag' : 'fr-icon-error-warning-line',
+                      },
+                      ...(territoire.surface
+                        ? [
+                            {
+                              content: `${Math.round(territoire.surface)} ha`,
+                              iconId: 'fr-icon-ruler-line',
+                            },
+                          ]
+                        : []),
+                      ...(territoire.nb_captages_actifs
+                        ? [
+                            {
+                              content: `${territoire.nb_captages_actifs} captage${territoire.nb_captages_actifs > 1 ? 's' : ''} actif${territoire.nb_captages_actifs > 1 ? 's' : ''}`,
+                              iconId: 'fr-icon-water-line',
+                            },
+                          ]
+                        : []),
+                      ...(territoire.nb_communes
+                        ? [
+                            {
+                              content: `${territoire.nb_communes} commune${territoire.nb_communes > 1 ? 's' : ''}`,
+                              iconId: 'fr-icon-government-line',
+                            },
+                          ]
+                        : []),
+                    ]}
+                  />
+                )
+              })}
+            </div>
+
+            {meta.lastPage > 1 && (
+              <div className="fr-mt-4w flex justify-center">
+                <Pagination
+                  count={meta.lastPage}
+                  defaultPage={meta.currentPage}
+                  getPageLinkProps={(pageNumber) => ({
+                    href: `?territoiresPage=${pageNumber}`,
+                  })}
+                />
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Layout>
+  )
+}

--- a/inertia/ui/layouts/layout.tsx
+++ b/inertia/ui/layouts/layout.tsx
@@ -47,6 +47,11 @@ export default function Layout({
                   isActive: pathname.startsWith('/exploitations'),
                 },
                 {
+                  linkProps: { href: '/territoires' },
+                  text: 'Mes territoires',
+                  isActive: pathname.startsWith('/territoires'),
+                },
+                {
                   linkProps: { href: '/aac' },
                   text: 'AAC',
                   isActive: pathname.startsWith('/aac'),

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -17,6 +17,7 @@ const LogEntriesController = () => import('#controllers/log_entries_controller')
 const VisualisationController = () => import('#controllers/visualisation_controller')
 const AacController = () => import('#controllers/aac_controller')
 const ProjectsController = () => import('#controllers/projects_controller')
+const TerritoiresController = () => import('#controllers/territoires_controller')
 
 router.get('/', ({ response }) => response.redirect('login')).as('root')
 
@@ -225,6 +226,8 @@ router
         router.post('projets', [ProjectsController, 'store']).as('projets.store')
         router.patch('projets/:projectId', [ProjectsController, 'update']).as('projets.update')
         router.delete('projets/:projectId', [ProjectsController, 'destroy']).as('projets.destroy')
+
+        router.get('territoires', [TerritoiresController, 'index']).as('territoires.index')
       })
       .use(middleware.territoireAssignation())
   })

--- a/tests/functional/territoire/territoires_index.spec.ts
+++ b/tests/functional/territoire/territoires_index.spec.ts
@@ -4,10 +4,49 @@ import { UserFactory } from '#database/factories/user_factory'
 import { TerritoireFactory } from '#database/factories/territoire_factory'
 import { inertiaApiClient } from '@adonisjs/inertia/plugins/api_client'
 import app from '@adonisjs/core/services/app'
+import { AacService } from '#services/aac_service'
+
+function createMockAacService(): AacService {
+  return {
+    async getAll(
+      _page: number,
+      _perPage: number,
+      _recherche?: string,
+      _commune?: string,
+      aacCodes?: string[]
+    ) {
+      const codes = aacCodes ?? []
+
+      return {
+        data: codes.map((code) => ({
+          code,
+          nom: `AAC ${code}`,
+          surface: code === '12345' ? 150.5 : 0,
+          nb_captages_actifs: code === '12345' ? 3 : 0,
+          communes:
+            code === '12345' ? { nb_communes: 2, communes: {} } : { nb_communes: 0, communes: {} },
+          date_maj: '2024-01-01',
+          date_creation: '2020-01-01',
+          bbox: null,
+          nb_parcelles: 0,
+          surface_agricole_bio: null,
+          surface_agricole_ppe: null,
+          surface_agricole_ppr: null,
+          surface_agricole_utile: null,
+        })),
+        total: codes.length,
+      }
+    },
+  } as unknown as AacService
+}
 
 test.group('Territoires - Index Route', (group) => {
   group.setup(async () => {
     await (inertiaApiClient(app) as () => Promise<void>)()
+  })
+  group.each.setup(() => {
+    app.container.swap(AacService, () => createMockAacService())
+    return () => app.container.restore(AacService)
   })
   group.each.setup(() => testUtils.db().withGlobalTransaction())
 
@@ -44,9 +83,15 @@ test.group('Territoires - Index Route', (group) => {
     assert.equal(territoireWithAacLink.code, '12345')
     assert.equal(territoireWithAacLink.aacHref, '/aac/12345')
     assert.equal(territoireWithAacLink.typeLabel, 'AAC Sandre')
+    assert.equal(territoireWithAacLink.surface, 150.5)
+    assert.equal(territoireWithAacLink.nb_communes, 2)
+    assert.equal(territoireWithAacLink.nb_captages_actifs, 3)
     assert.isNull(territoireWithoutAacLink.code)
     assert.isNull(territoireWithoutAacLink.aacHref)
     assert.equal(territoireWithoutAacLink.typeLabel, 'Autre territoire')
+    assert.isNull(territoireWithoutAacLink.surface)
+    assert.isNull(territoireWithoutAacLink.nb_communes)
+    assert.isNull(territoireWithoutAacLink.nb_captages_actifs)
   })
 
   test('user gets paginated territoires', async ({ assert, client, route }) => {

--- a/tests/functional/territoire/territoires_index.spec.ts
+++ b/tests/functional/territoire/territoires_index.spec.ts
@@ -1,0 +1,93 @@
+import { test } from '@japa/runner'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { UserFactory } from '#database/factories/user_factory'
+import { TerritoireFactory } from '#database/factories/territoire_factory'
+import { inertiaApiClient } from '@adonisjs/inertia/plugins/api_client'
+import app from '@adonisjs/core/services/app'
+
+test.group('Territoires - Index Route', (group) => {
+  group.setup(async () => {
+    await (inertiaApiClient(app) as () => Promise<void>)()
+  })
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('user can list all territoires associated to their account', async ({
+    assert,
+    client,
+    route,
+  }) => {
+    const user = await UserFactory.create()
+    const aacTerritoire = await TerritoireFactory.merge({ code: '12345' }).create()
+    const nonAacTerritoire = await TerritoireFactory.apply('nonAAC').create()
+
+    await user.related('territoires').attach([aacTerritoire.id, nonAacTerritoire.id])
+
+    const response = await client.get(route('territoires.index')).loginAs(user).withInertia()
+
+    response.assertStatus(200)
+
+    const responseBody = response.body()
+    assert.equal(responseBody.component, 'territoires/index')
+
+    const territoires = responseBody.props.territoires
+    assert.lengthOf(territoires, 2)
+
+    const territoireWithAacLink = territoires.find((territoire: { id: string }) => {
+      return territoire.id === aacTerritoire.id
+    })
+    const territoireWithoutAacLink = territoires.find((territoire: { id: string }) => {
+      return territoire.id === nonAacTerritoire.id
+    })
+
+    assert.isDefined(territoireWithAacLink)
+    assert.isDefined(territoireWithoutAacLink)
+    assert.equal(territoireWithAacLink.code, '12345')
+    assert.equal(territoireWithAacLink.aacHref, '/aac/12345')
+    assert.equal(territoireWithAacLink.typeLabel, 'AAC Sandre')
+    assert.isNull(territoireWithoutAacLink.code)
+    assert.isNull(territoireWithoutAacLink.aacHref)
+    assert.equal(territoireWithoutAacLink.typeLabel, 'Autre territoire')
+  })
+
+  test('user gets paginated territoires', async ({ assert, client, route }) => {
+    const user = await UserFactory.create()
+    const territoires = await TerritoireFactory.createMany(21)
+
+    await user.related('territoires').attach(territoires.map((territoire) => territoire.id))
+
+    const response = await client
+      .get(route('territoires.index', {}, { qs: { territoiresPage: 2 } }))
+      .loginAs(user)
+      .withInertia()
+
+    response.assertStatus(200)
+
+    const responseBody = response.body()
+    assert.equal(responseBody.component, 'territoires/index')
+    assert.equal(responseBody.props.meta.currentPage, 2)
+    assert.equal(responseBody.props.meta.lastPage, 2)
+    assert.equal(responseBody.props.territoires.length, 1)
+  })
+
+  test("user cannot see another user's territoires", async ({ assert, client, route }) => {
+    const user = await UserFactory.create()
+    const anotherUser = await UserFactory.create()
+    const myTerritoire = await TerritoireFactory.create()
+    const otherTerritoire = await TerritoireFactory.create()
+
+    await user.related('territoires').attach([myTerritoire.id])
+    await anotherUser.related('territoires').attach([otherTerritoire.id])
+
+    const response = await client.get(route('territoires.index')).loginAs(user).withInertia()
+
+    response.assertStatus(200)
+
+    const responseBody = response.body()
+    const territoireIds = responseBody.props.territoires.map((territoire: { id: string }) => {
+      return territoire.id
+    })
+
+    assert.include(territoireIds, myTerritoire.id)
+    assert.notInclude(territoireIds, otherTerritoire.id)
+  })
+})

--- a/types/models.ts
+++ b/types/models.ts
@@ -29,8 +29,18 @@ export type ExploitationTagJson = {
 
 export type TerritoireJson = {
   id: string
-  name: string | null
+  nom: string
   code: string | null
+  typeLabel: string
+  aacHref: string | null
+  surface: number | null
+  nb_captages_actifs: number | null
+  nb_communes: number | null
+  date_maj: string | null
+  date_creation: string | null
+  bbox: [number, number, number, number] | null
+  communes: Record<string, CommuneInfo> | null
+  nb_parcelles: number | null
 }
 
 export type LogEntryTagJson = {

--- a/types/models.ts
+++ b/types/models.ts
@@ -39,7 +39,7 @@ export type TerritoireJson = {
   date_maj: string | null
   date_creation: string | null
   bbox: [number, number, number, number] | null
-  communes: Record<string, CommuneInfo> | null
+  communes: { nb_communes: number; communes: Record<string, CommuneInfo> } | null
   nb_parcelles: number | null
 }
 


### PR DESCRIPTION
Cette pull request introduit une nouvelle fonctionnalité **« Mes territoires »**, permettant aux utilisateurs de consulter et de parcourir de manière paginée les territoires associés à leur compte. L’implémentation comprend un nouveau contrôleur, une nouvelle route, une page Inertia, des mises à jour des types de données et des DTO, ainsi qu’une couverture de tests complète afin de garantir le bon fonctionnement de la fonctionnalité et le respect des règles d’accès.

**Nouvelle fonctionnalité « Mes territoires » :**

* Ajout d’un nouveau `TerritoiresController` avec une action `index` permettant de récupérer et de paginer les territoires associés à l’utilisateur, avec enrichissement des données AAC lorsque celles-ci sont disponibles.
* Création d’une nouvelle page Inertia `territoires/index` pour afficher les territoires de l’utilisateur, avec prise en charge de la pagination et affichage détaillé des informations du territoire.
* Ajout du lien **« Mes territoires »** dans la navigation principale afin de faciliter l’accès à cette fonctionnalité.
* Enregistrement de la nouvelle route `/territoires`, protégée par les middlewares d’authentification et d’affectation des territoires.

**Améliorations du modèle de données et des DTO :**

* Extension du type `TerritoireJson` et du `TerritoireDto` avec de nouveaux champs (`nom`, `typeLabel`, `aacHref`, `surface`, `nb_captages_actifs`, `nb_communes`, etc.) afin de fournir des informations plus riches sur les territoires côté frontend.

**Tests :**

* Ajout de tests fonctionnels pour vérifier l’affichage de la liste, la pagination et le contrôle d’accès de la nouvelle fonctionnalité « Mes territoires », garantissant que chaque utilisateur ne visualise que ses propres territoires et que les données AAC sont correctement affichées.

<img width="3385" height="1900" alt="Movavi ScreenShot 037 - Mes territoires - Viz’Eau - localhost" src="https://github.com/user-attachments/assets/39a160ca-0533-4c45-b8fb-97a8f0e24dad" />
