### PR TITLE
Correction de l'affichage du type d'action d'un projet

### DIFF
--- a/inertia/components/projets/projet-infos-card.tsx
+++ b/inertia/components/projets/projet-infos-card.tsx
@@ -44,7 +44,10 @@ export default function ProjetInfosCard({ projet }: { projet: ProjectJson }) {
         <LabelInfo label="Créé le" info={formatDateFr(createdAt)} />
         <LabelInfo label="Mis à jour le" info={formatDateFr(updatedAt)} />
         {closedAt && <LabelInfo label="Clôturé le" info={formatDateFr(closedAt)} />}
-        <LabelInfo label="Type d'action" info={actionType} />
+        <LabelInfo
+          label="Type d'action"
+          info={<CustomTag label={actionType || 'Non renseigné'} color="rgb(186, 217, 247)" />}
+        />
       </div>
     </SectionCard>
   )


### PR DESCRIPTION
Cette pull request met à jour l’affichage du champ **« Type d’action »** dans le composant `ProjetInfosCard` afin d’améliorer sa présentation visuelle et de mieux gérer les données manquantes.

**Améliorations de l’interface utilisateur :**

* Le champ **« Type d’action »** utilise désormais le composant `CustomTag` pour un affichage plus distinct visuellement. Lorsqu’aucune valeur n’est renseignée, le texte **« Non renseigné »** est affiché avec une couleur de fond spécifique.


### **AVANT**
<img width="426" height="741" alt="609279908-dc53998d-67aa-4cf6-a2ad-fe7ddd0da029" src="https://github.com/user-attachments/assets/174df5ac-19f9-4e81-966b-242c6172b49a" />

### **APRÈS**
<img width="496" height="617" alt="Capture d’écran 2026-06-18 à 09 00 44" src="https://github.com/user-attachments/assets/05426ab2-a387-4b4d-9d47-ac048a0d295b" />

Close #449 