### PR TITLE
Ajout d'un bouton de navigation vers la sélection de parcelles

### DIFF
--- a/app/controllers/visualisation_controller.ts
+++ b/app/controllers/visualisation_controller.ts
@@ -30,7 +30,9 @@ export default class VisualisationController {
   async index({ request, response, inertia, auth }: HttpContext) {
     // Ensure millesime is present in query string
     if (!request.qs().millesime) {
-      return response.redirect().withQs('millesime', '2024').toPath(request.url())
+      const qs = request.qs()
+      qs.millesime = '2024'
+      return response.redirect().toPath(`/visualisation?${new URLSearchParams(qs).toString()}`)
     }
 
     const user = auth.getUserOrFail()

--- a/inertia/components/exploitation-id/ExploitationParcelles.tsx
+++ b/inertia/components/exploitation-id/ExploitationParcelles.tsx
@@ -19,9 +19,7 @@ export default function ExploitationParcelles({
         illustrativeIcon="fr-icon-collage-line"
         buttonLabel="Ajouter des parcelles"
         buttonIcon="fr-icon-add-line"
-        handleClick={() =>
-          router.visit(`/visualisation?millesime=2024&exploitationId=${exploitationId}`)
-        }
+        handleClick={() => router.visit(`/visualisation?exploitationId=${exploitationId}`)}
       />
     )
   }

--- a/inertia/components/exploitation-id/ExploitationParcelles.tsx
+++ b/inertia/components/exploitation-id/ExploitationParcelles.tsx
@@ -1,3 +1,4 @@
+import { router } from '@inertiajs/react'
 import EmptyPlaceholder from '~/ui/EmptyPlaceholder'
 import ExploitationParcellesList from '../parcelle/exploitations-parcelles-list'
 import { ParcelleJson } from '#types/models'
@@ -16,6 +17,11 @@ export default function ExploitationParcelles({
       <EmptyPlaceholder
         label="Aucune parcelle associée pour le moment"
         illustrativeIcon="fr-icon-collage-line"
+        buttonLabel="Ajouter des parcelles"
+        buttonIcon="fr-icon-add-line"
+        handleClick={() =>
+          router.visit(`/visualisation?millesime=2024&exploitationId=${exploitationId}`)
+        }
       />
     )
   }

--- a/inertia/components/parcelle/exploitations-parcelles-list.tsx
+++ b/inertia/components/parcelle/exploitations-parcelles-list.tsx
@@ -45,9 +45,7 @@ export default function ExploitationParcellesList({
         aria-label={`Gérer les parcelles de l'exploitation`}
         iconId="fr-icon-edit-line"
         style={{ width: '100%', justifyContent: 'center' }}
-        onClick={() =>
-          router.visit(`/visualisation?millesime=2024&exploitationId=${exploitationId}`)
-        }
+        onClick={() => router.visit(`/visualisation?exploitationId=${exploitationId}`)}
       >
         Gérer les parcelles
       </Button>

--- a/inertia/components/parcelle/exploitations-parcelles-list.tsx
+++ b/inertia/components/parcelle/exploitations-parcelles-list.tsx
@@ -8,6 +8,7 @@ import CommentFormModal from '../parcelle/comment-form-modal'
 import ExploitationsController from '#controllers/exploitations_controller'
 import { FlashMessages } from '../flash-message'
 import { getCultureByCode } from '~/functions/cultures-group'
+import Button from '@codegouvfr/react-dsfr/Button'
 
 export type ExploitationParcellesListProps = {
   parcelles: ParcelleJson[]
@@ -39,6 +40,17 @@ export default function ExploitationParcellesList({
   return (
     <div className="flex flex-col gap-4">
       <FlashMessages flashMessages={flashMessages} context="parcelle" />
+      <Button
+        priority="secondary"
+        aria-label={`Gérer les parcelles de l'exploitation`}
+        iconId="fr-icon-edit-line"
+        style={{ width: '100%', justifyContent: 'center' }}
+        onClick={() =>
+          router.visit(`/visualisation?millesime=2024&exploitationId=${exploitationId}`)
+        }
+      >
+        Gérer les parcelles
+      </Button>
       {parcelles.map((parcelle) => (
         <ListItem
           key={`${parcelle.rpgId}-${parcelle.year}`}


### PR DESCRIPTION
Cette pull request améliore l’expérience utilisateur lors de la gestion des parcelles associées à une exploitation. Les principales évolutions ajoutent des boutons d’action explicites pour ajouter ou gérer les parcelles, aussi bien dans l’état vide que dans la vue liste, rendant la navigation plus intuitive.

**Améliorations de l’interface utilisateur :**

* Ajout d’un bouton **« Ajouter des parcelles »** dans le composant `EmptyPlaceholder` de `ExploitationParcelles`, permettant aux utilisateurs d’ajouter directement des parcelles lorsqu’aucune n’est associée à l’exploitation. Le bouton inclut une icône et redirige vers la page de gestion des parcelles.
* Ajout d’un bouton **« Gérer les parcelles »** en haut du composant `ExploitationParcellesList`, mis en avant par son style et son accessibilité, et permettant également d’accéder à la page de gestion des parcelles.

**Améliorations du code :**

* Import du composant `Button` depuis `@codegouvfr/react-dsfr` afin de standardiser l’utilisation des boutons et de garantir la cohérence avec le design system.
* Ajout de l’import manquant de `router` depuis `@inertiajs/react` dans `ExploitationParcelles` afin de permettre la navigation associée aux nouveaux boutons.


<img width="1394" height="960" alt="Capture d’écran 2026-06-18 à 11 15 27" src="https://github.com/user-attachments/assets/0654098d-0621-474a-aa3a-9551edc5dd40" />

<img width="1396" height="1079" alt="Capture d’écran 2026-06-18 à 11 15 58" src="https://github.com/user-attachments/assets/cfba44fd-7411-4dca-a8c7-8033219d3ca9" />

Close #446