### PR TITLE
Correction affichage des longs titres de liste

### DIFF
--- a/inertia/pages/projets/id.tsx
+++ b/inertia/pages/projets/id.tsx
@@ -121,7 +121,7 @@ export default function ShowProjet({ projet }: InferPageProps<ProjectsController
             </deleteProjetModal.Component>
           </aside>
 
-          <div>
+          <div className="min-w-0">
             <CallOut
               title="Description du projet"
               {...(projet.description &&

--- a/inertia/ui/ListItem/index.tsx
+++ b/inertia/ui/ListItem/index.tsx
@@ -147,8 +147,8 @@ export default function ListItem({
             )}
             <div>
               <div className="items-center flex gap-2">
-                <div className="flex flex-1 items-center gap-2 flex-wrap">
-                  <div className="flex items-center gap-1">
+                <div className="flex flex-1 items-center gap-2 flex-wrap min-w-0">
+                  <div className="flex items-center gap-1 min-w-0">
                     {iconId && (
                       <span
                         className={`${iconId} fr-icon--md`}
@@ -157,9 +157,11 @@ export default function ListItem({
                       ></span>
                     )}
                     {typeof title === 'string' ? (
-                      <TruncatedText maxLines={1} className="flex-1 fr-m-0 fr-text--md font-bold">
-                        {title}
-                      </TruncatedText>
+                      <div className="flex-1 min-w-0 overflow-hidden">
+                        <TruncatedText maxLines={1} className="fr-m-0 fr-text--md font-bold">
+                          {title}
+                        </TruncatedText>
+                      </div>
                     ) : (
                       <div className="flex-1">{title}</div>
                     )}
@@ -207,8 +209,8 @@ export default function ListItem({
           {tags && tags.length > 0 && <TagsList tags={tags} size="sm" limit={5} />}
 
           <div className="flex items-start">
-            <div className="flex flex-1 flex-col">
-              <div className="flex items-center gap-1">
+            <div className="flex flex-1 flex-col min-w-0">
+              <div className="flex items-center gap-1 min-w-0">
                 {iconId && (
                   <span
                     className={`${iconId} fr-icon--md`}
@@ -217,13 +219,15 @@ export default function ListItem({
                   ></span>
                 )}
                 {typeof title === 'string' ? (
-                  <TruncatedText
-                    maxLines={1}
-                    className="flex-1 fr-m-0 fr-text--md font-bold"
-                    hideTooltip={hideTooltip}
-                  >
-                    {title}
-                  </TruncatedText>
+                  <div className="flex-1 min-w-0 overflow-hidden">
+                    <TruncatedText
+                      maxLines={1}
+                      className="fr-m-0 fr-text--md font-bold"
+                      hideTooltip={hideTooltip}
+                    >
+                      {title}
+                    </TruncatedText>
+                  </div>
                 ) : (
                   title
                 )}

--- a/inertia/ui/ListItem/index.tsx
+++ b/inertia/ui/ListItem/index.tsx
@@ -157,7 +157,7 @@ export default function ListItem({
                       ></span>
                     )}
                     {typeof title === 'string' ? (
-                      <div className="flex-1 min-w-0 overflow-hidden">
+                      <div className="flex-1 min-w-0">
                         <TruncatedText maxLines={1} className="fr-m-0 fr-text--md font-bold">
                           {title}
                         </TruncatedText>
@@ -219,7 +219,7 @@ export default function ListItem({
                   ></span>
                 )}
                 {typeof title === 'string' ? (
-                  <div className="flex-1 min-w-0 overflow-hidden">
+                  <div className="flex-1 min-w-0">
                     <TruncatedText
                       maxLines={1}
                       className="fr-m-0 fr-text--md font-bold"

--- a/inertia/ui/Timeline/index.tsx
+++ b/inertia/ui/Timeline/index.tsx
@@ -129,7 +129,10 @@ export default function Timeline(props: TimelineProps) {
                 <span>{getButtonLabel()}</span>
               </Button>
             ) : (
-              <div className="fr-mb-5v w-full" style={{ paddingTop: '6px', paddingBottom: '6px' }}>
+              <div
+                className="fr-mb-5v w-full min-w-0"
+                style={{ paddingTop: '6px', paddingBottom: '6px' }}
+              >
                 {item.content}
               </div>
             )}


### PR DESCRIPTION
Cette pull request vise à améliorer la gestion des débordements de texte et la cohérence des mises en page dans plusieurs composants de l’interface en ajoutant les classes utilitaires `min-w-0` et `overflow-hidden`. Ces changements permettent d’éviter les problèmes d’affichage, notamment dans les conteneurs flexibles, en garantissant que les contenus textuels longs sont correctement tronqués sans casser la mise en page.

**Améliorations de la mise en page et de la gestion des débordements de texte :**

* Ajout des classes `min-w-0` et `overflow-hidden` aux conteneurs flexibles et aux éléments englobant du texte dans `ListItem`, afin de garantir que les titres et contenus longs sont correctement tronqués et ne débordent pas de leur conteneur.
* Mise à jour de la section de description du projet dans `ShowProjet` avec l’ajout de `min-w-0`, améliorant sa réactivité et empêchant les débordements de contenu.
* Amélioration du rendu des éléments de la frise chronologique dans `Timeline` grâce à l’ajout de `min-w-0`, assurant une gestion cohérente des largeurs de contenu.

### **Avant**
<img width="1324" height="597" alt="Capture d’écran 2026-06-19 à 16 43 34" src="https://github.com/user-attachments/assets/bbf4f550-6344-45ea-880c-793f4163459c" />
<img width="1459" height="933" alt="Capture d’écran 2026-06-19 à 16 43 54" src="https://github.com/user-attachments/assets/8f529a43-d3e2-40ee-a4bf-99fae5ff9308" />

### **Après**
<img width="1482" height="770" alt="Capture d’écran 2026-06-22 à 09 31 35" src="https://github.com/user-attachments/assets/ef2ace65-17b2-417f-8b87-56943fba5a87" />

Close #454