### PR TITLE
Implémentation de l'upload de document pour les étapes de projet

### DIFF
--- a/app/controllers/project_steps_controller.ts
+++ b/app/controllers/project_steps_controller.ts
@@ -1,0 +1,239 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { DateTime } from 'luxon'
+import ProjectStepDocument from '#models/project_step_document'
+import { ProjectService } from '#services/project_service'
+import { ProjectStepService } from '#services/project_step_service'
+import { ProjectStepDocumentService } from '#services/project_step_document_service'
+import {
+  completeProjectStepValidator,
+  createProjectStepPayloadValidator,
+  destroyProjectStepDocumentValidator,
+  downloadProjectStepDocumentValidator,
+  showProjectStepValidator,
+  updateProjectStepPayloadValidator,
+} from '#validators/project_step'
+import { showProjectValidator } from '#validators/project'
+import { ProjectDto } from '../dto/project_dto.js'
+import { ProjectStepDto } from '../dto/project_step_dto.js'
+import { createErrorFlashMessage, createSuccessFlashMessage } from '../helpers/flash_message.js'
+import router from '@adonisjs/core/services/router'
+
+@inject()
+export default class ProjectStepsController {
+  constructor(
+    public projectService: ProjectService,
+    public projectStepService: ProjectStepService,
+    public projectStepDocumentService: ProjectStepDocumentService
+  ) {}
+
+  async createStepForm({ auth, request, inertia }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params } = await request.validateUsing(showProjectValidator)
+    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+
+    return inertia.render('projets/etapes/creation', {
+      projet: ProjectDto.fromModel(project),
+      createStepUrl: router.builder().params([project.id]).make('projets.steps.create'),
+    })
+  }
+
+  async createStep({ auth, request, response, session }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params } = await request.validateUsing(showProjectValidator)
+    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+
+    const data = await request.validateUsing(createProjectStepPayloadValidator)
+    const { title, note, date: dateInput, tags } = data
+
+    if (!title && !note && !dateInput) {
+      createErrorFlashMessage(session, "Veuillez renseigner au moins un champ pour créer l'étape.")
+      return response.redirect().back()
+    }
+
+    const createdStep = await this.projectStepService.createStep(
+      project,
+      {
+        title,
+        note,
+        date: dateInput ? DateTime.fromISO(dateInput) : null,
+      },
+      tags
+    )
+
+    for (const document of request.files('documents') || []) {
+      await this.projectStepDocumentService.createDocument(createdStep.id, document)
+    }
+
+    createSuccessFlashMessage(session, "L'étape a été créée avec succès.")
+    return response.redirect().toRoute('projets.show', { projectId: project.id })
+  }
+
+  async getStep({ auth, request, inertia }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params } = await request.validateUsing(showProjectStepValidator)
+    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+
+    const step = await this.projectStepService.getStepForProject(params.stepId, project)
+
+    return inertia.render('projets/etapes/id', {
+      projet: {
+        id: project.id,
+        name: project.name,
+      },
+      step: ProjectStepDto.fromModel(step)!,
+      deleteStepUrl: router.builder().params([project.id, step.id]).make('projets.steps.destroy'),
+      completeStepUrl: router.builder().params([project.id]).make('projets.steps.complete'),
+    })
+  }
+
+  async getStepForEdition({ auth, request, inertia }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params } = await request.validateUsing(showProjectStepValidator)
+
+    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+    const step = await this.projectStepService.getStepForProject(params.stepId, project)
+
+    return inertia.render('projets/etapes/edition', {
+      projet: ProjectDto.fromModel(project),
+      step: ProjectStepDto.fromModel(step)!,
+      editStepUrl: router.builder().params([project.id, step.id]).make('projets.steps.edit'),
+    })
+  }
+
+  async editStep({ auth, request, response, session }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params } = await request.validateUsing(showProjectStepValidator)
+    const stepId = params.stepId
+    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+
+    const data = await request.validateUsing(updateProjectStepPayloadValidator)
+    const { title, note, date: dateInput, tags, removedDocumentIds = [] } = data
+
+    if (!title && !note && !dateInput) {
+      createErrorFlashMessage(
+        session,
+        "Veuillez renseigner au moins un champ pour modifier l'étape."
+      )
+      return response.redirect().back()
+    }
+
+    await this.projectStepService.updateStep(
+      stepId,
+      project,
+      {
+        title,
+        note,
+        date: dateInput ? DateTime.fromISO(dateInput) : null,
+      },
+      tags
+    )
+
+    for (const document of request.files('documents') || []) {
+      await this.projectStepDocumentService.createDocument(stepId, document)
+    }
+
+    if (removedDocumentIds.length > 0) {
+      const documentsToDelete = await ProjectStepDocument.query()
+        .where('projectStepId', stepId)
+        .whereIn('id', removedDocumentIds)
+
+      for (const document of documentsToDelete) {
+        await document.delete()
+      }
+    }
+
+    createSuccessFlashMessage(session, "L'étape a été modifiée avec succès.")
+    return response.redirect().toPath(`/projets/${project.id}`)
+  }
+
+  async destroyStep({ auth, request, response, session }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params } = await request.validateUsing(showProjectStepValidator)
+    const stepId = params.stepId
+    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+
+    const documents = await ProjectStepDocument.query().where('projectStepId', stepId)
+    for (const document of documents) {
+      await document.delete()
+    }
+    await this.projectStepService.deleteStep(stepId, project)
+
+    createSuccessFlashMessage(session, "L'étape a été supprimée.")
+    return response.redirect().toPath(`/projets/${project.id}`)
+  }
+
+  async downloadStepDocument({ auth, request, response, logger, session, inertia }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params } = await request.validateUsing(downloadProjectStepDocumentValidator)
+
+    try {
+      const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+      await this.projectStepService.getStepForProject(params.stepId, project)
+
+      const document = await ProjectStepDocument.query()
+        .where('projectStepId', params.stepId)
+        .andWhere('id', params.documentId)
+        .first()
+
+      if (!document) {
+        logger.error(
+          `Document with ID ${params.documentId} not found for user ${user.id} in step ${params.stepId}`
+        )
+        createErrorFlashMessage(session, 'Impossible de trouver le document.')
+        return response.redirect().back()
+      }
+
+      const url = await this.projectStepDocumentService.getDocumentUrl(document.s3Key)
+
+      return inertia.location(url)
+    } catch (error) {
+      logger.error(error, 'Error downloading project step document:')
+      createErrorFlashMessage(
+        session,
+        'Une erreur est survenue lors du téléchargement du document.'
+      )
+      return response.redirect().back()
+    }
+  }
+
+  async destroyDocument({ auth, request, response, session }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params, documentId } = await request.validateUsing(destroyProjectStepDocumentValidator)
+
+    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+    await this.projectStepService.getStepForProject(params.stepId, project)
+
+    const document = await ProjectStepDocument.query()
+      .where('projectStepId', params.stepId)
+      .andWhere('id', documentId)
+      .first()
+
+    if (!document) {
+      createErrorFlashMessage(session, 'Impossible de trouver le document.')
+      return response.redirect().back()
+    }
+
+    await document.delete()
+    createSuccessFlashMessage(session, 'Le document a été supprimé avec succès.')
+    return response.redirect().back()
+  }
+
+  async completeStep({ auth, request, response, session }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { params, id } = await request.validateUsing(completeProjectStepValidator)
+    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
+
+    await this.projectStepService.updateStep(
+      id,
+      project,
+      {
+        isValidated: true,
+      },
+      undefined
+    )
+
+    createSuccessFlashMessage(session, "L'étape a été marquée comme effectuée.")
+    return response.redirect().toPath(`/projets/${project.id}`)
+  }
+}

--- a/app/controllers/project_steps_controller.ts
+++ b/app/controllers/project_steps_controller.ts
@@ -84,6 +84,10 @@ export default class ProjectStepsController {
       step: ProjectStepDto.fromModel(step)!,
       deleteStepUrl: router.builder().params([project.id, step.id]).make('projets.steps.destroy'),
       completeStepUrl: router.builder().params([project.id]).make('projets.steps.complete'),
+      deleteDocumentUrl: router
+        .builder()
+        .params([project.id, step.id])
+        .make('projets.steps.documents.destroy'),
     })
   }
 
@@ -98,6 +102,10 @@ export default class ProjectStepsController {
       projet: ProjectDto.fromModel(project),
       step: ProjectStepDto.fromModel(step)!,
       editStepUrl: router.builder().params([project.id, step.id]).make('projets.steps.edit'),
+      deleteDocumentUrl: router
+        .builder()
+        .params([project.id, step.id])
+        .make('projets.steps.documents.destroy'),
     })
   }
 

--- a/app/controllers/projects_controller.ts
+++ b/app/controllers/projects_controller.ts
@@ -1,13 +1,9 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
-import { DateTime } from 'luxon'
 import Parcelle from '#models/parcelle'
 import Captage from '#models/captage'
-import ProjectStepDocument from '#models/project_step_document'
 import { ProjectService } from '#services/project_service'
 import { ExploitationService } from '#services/exploitation_service'
-import { ProjectStepService } from '#services/project_step_service'
-import { ProjectStepDocumentService } from '#services/project_step_document_service'
 import env from '#start/env'
 import {
   createProjectValidator,
@@ -20,16 +16,6 @@ import { ProjectDto } from '../dto/project_dto.js'
 import { ExploitationDto } from '../dto/exploitation_dto.js'
 import { CaptageDto } from '../dto/captage_dto.js'
 import { createErrorFlashMessage, createSuccessFlashMessage } from '../helpers/flash_message.js'
-import { ProjectStepDto } from '../dto/project_step_dto.js'
-import {
-  completeProjectStepValidator,
-  createProjectStepPayloadValidator,
-  destroyProjectStepDocumentValidator,
-  downloadProjectStepDocumentValidator,
-  showProjectStepValidator,
-  updateProjectStepPayloadValidator,
-} from '#validators/project_step'
-import router from '@adonisjs/core/services/router'
 
 @inject()
 export default class ProjectsController {
@@ -37,9 +23,7 @@ export default class ProjectsController {
 
   constructor(
     public projectService: ProjectService,
-    public exploitationService: ExploitationService,
-    public projectStepService: ProjectStepService,
-    public projectStepDocumentService: ProjectStepDocumentService
+    public exploitationService: ExploitationService
   ) {}
 
   async index({ auth, inertia, request }: HttpContext) {
@@ -400,216 +384,6 @@ export default class ProjectsController {
       },
       pmtilesUrl: env.get('PMTILES_URL', ''),
     })
-  }
-
-  async createStepForm({ auth, request, inertia }: HttpContext) {
-    const user = auth.getUserOrFail()
-    const { params } = await request.validateUsing(showProjectValidator)
-    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
-
-    return inertia.render('projets/etapes/creation', {
-      projet: ProjectDto.fromModel(project),
-      createStepUrl: router.builder().params([project.id]).make('projets.steps.create'),
-    })
-  }
-
-  async createStep({ auth, request, response, session }: HttpContext) {
-    const user = auth.getUserOrFail()
-    const { params } = await request.validateUsing(showProjectValidator)
-    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
-
-    const data = await request.validateUsing(createProjectStepPayloadValidator)
-    const { title, note, date: dateInput, tags } = data
-
-    if (!title && !note && !dateInput) {
-      createErrorFlashMessage(session, "Veuillez renseigner au moins un champ pour créer l'étape.")
-      return response.redirect().back()
-    }
-
-    const createdStep = await this.projectStepService.createStep(
-      project,
-      {
-        title,
-        note,
-        date: dateInput ? DateTime.fromISO(dateInput) : null,
-      },
-      tags
-    )
-
-    for (const document of request.files('documents') || []) {
-      await this.projectStepDocumentService.createDocument(createdStep.id, document)
-    }
-
-    createSuccessFlashMessage(session, "L'étape a été créée avec succès.")
-    return response.redirect().toRoute('projets.show', { projectId: project.id })
-  }
-
-  async getStep({ auth, request, inertia }: HttpContext) {
-    const user = auth.getUserOrFail()
-    const { params } = await request.validateUsing(showProjectStepValidator)
-    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
-
-    const step = await this.projectStepService.getStepForProject(params.stepId, project)
-
-    return inertia.render('projets/etapes/id', {
-      projet: {
-        id: project.id,
-        name: project.name,
-      },
-      step: ProjectStepDto.fromModel(step)!,
-      deleteStepUrl: router.builder().params([project.id, step.id]).make('projets.steps.destroy'),
-      completeStepUrl: router.builder().params([project.id]).make('projets.steps.complete'),
-    })
-  }
-
-  async getStepForEdition({ auth, request, inertia }: HttpContext) {
-    const user = auth.getUserOrFail()
-    const { params } = await request.validateUsing(showProjectStepValidator)
-
-    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
-    const step = await this.projectStepService.getStepForProject(params.stepId, project)
-
-    return inertia.render('projets/etapes/edition', {
-      projet: ProjectDto.fromModel(project),
-      step: ProjectStepDto.fromModel(step)!,
-      editStepUrl: router.builder().params([project.id, step.id]).make('projets.steps.edit'),
-    })
-  }
-
-  async editStep({ auth, request, response, session }: HttpContext) {
-    const user = auth.getUserOrFail()
-    const { params } = await request.validateUsing(showProjectStepValidator)
-    const stepId = params.stepId
-    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
-
-    const data = await request.validateUsing(updateProjectStepPayloadValidator)
-    const { title, note, date: dateInput, tags, removedDocumentIds = [] } = data
-
-    if (!title && !note && !dateInput) {
-      createErrorFlashMessage(
-        session,
-        "Veuillez renseigner au moins un champ pour modifier l'étape."
-      )
-      return response.redirect().back()
-    }
-
-    await this.projectStepService.updateStep(
-      stepId,
-      project,
-      {
-        title,
-        note,
-        date: dateInput ? DateTime.fromISO(dateInput) : null,
-      },
-      tags
-    )
-
-    for (const document of request.files('documents') || []) {
-      await this.projectStepDocumentService.createDocument(stepId, document)
-    }
-
-    if (removedDocumentIds.length > 0) {
-      const documentsToDelete = await ProjectStepDocument.query()
-        .where('projectStepId', stepId)
-        .whereIn('id', removedDocumentIds)
-
-      for (const document of documentsToDelete) {
-        await document.delete()
-      }
-    }
-
-    createSuccessFlashMessage(session, "L'étape a été modifiée avec succès.")
-    return response.redirect().toPath(`/projets/${project.id}`)
-  }
-
-  async destroyStep({ auth, request, response, session }: HttpContext) {
-    const user = auth.getUserOrFail()
-    const { params } = await request.validateUsing(showProjectStepValidator)
-    const stepId = params.stepId
-    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
-
-    const documents = await ProjectStepDocument.query().where('projectStepId', stepId)
-    for (const document of documents) {
-      await document.delete()
-    }
-    await this.projectStepService.deleteStep(stepId, project)
-
-    createSuccessFlashMessage(session, "L'étape a été supprimée.")
-    return response.redirect().toPath(`/projets/${project.id}`)
-  }
-
-  async downloadStepDocument({ auth, request, response, logger, session, inertia }: HttpContext) {
-    const user = auth.getUserOrFail()
-    const { params } = await request.validateUsing(downloadProjectStepDocumentValidator)
-
-    try {
-      const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
-      await this.projectStepService.getStepForProject(params.stepId, project)
-
-      const document = await ProjectStepDocument.query()
-        .where('projectStepId', params.stepId)
-        .andWhere('id', params.documentId)
-        .first()
-
-      if (!document) {
-        logger.error(
-          `Document with ID ${params.documentId} not found for user ${user.id} in step ${params.stepId}`
-        )
-        createErrorFlashMessage(session, 'Impossible de trouver le document.')
-        return response.redirect().back()
-      }
-
-      const url = await this.projectStepDocumentService.getDocumentUrl(document.s3Key)
-
-      return inertia.location(url)
-    } catch (error) {
-      logger.error(error, 'Error downloading project step document:')
-      createErrorFlashMessage(
-        session,
-        'Une erreur est survenue lors du téléchargement du document.'
-      )
-      return response.redirect().back()
-    }
-  }
-
-  async destroyDocument({ auth, request, response, session }: HttpContext) {
-    const user = auth.getUserOrFail()
-    const { params, documentId } = await request.validateUsing(destroyProjectStepDocumentValidator)
-
-    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
-    await this.projectStepService.getStepForProject(params.stepId, project)
-
-    const document = await ProjectStepDocument.query()
-      .where('projectStepId', params.stepId)
-      .andWhere('id', documentId)
-      .first()
-
-    if (!document) {
-      createErrorFlashMessage(session, 'Impossible de trouver le document.')
-      return response.redirect().back()
-    }
-
-    await document.delete()
-    createSuccessFlashMessage(session, 'Le document a été supprimé avec succès.')
-    return response.redirect().back()
-  }
-
-  async completeStep({ auth, request, response, session }: HttpContext) {
-    const user = auth.getUserOrFail()
-    const { params, id } = await request.validateUsing(completeProjectStepValidator)
-    const project = await this.projectService.findOwnedProjectOrFail(params.projectId, user.id)
-
-    await this.projectStepService.updateStep(
-      id,
-      project,
-      {
-        isValidated: true,
-      },
-      undefined
-    )
-
-    createSuccessFlashMessage(session, "L'étape a été marquée comme effectuée.")
-    return response.redirect().toPath(`/projets/${project.id}`)
   }
 
   async update({ auth, request, response, session }: HttpContext) {

--- a/inertia/components/projets/ProjectStepDocumentList.tsx
+++ b/inertia/components/projets/ProjectStepDocumentList.tsx
@@ -1,0 +1,68 @@
+import FileItemsList from '~/ui/FileItemList'
+import { router } from '@inertiajs/react'
+import { ProjectStepDocumentJson } from '#types/models'
+import { createModal } from '@codegouvfr/react-dsfr/Modal'
+import { Alert } from '@codegouvfr/react-dsfr/Alert'
+import { useState } from 'react'
+
+const deleteDocumentModal = createModal({
+  id: 'delete-project-step-document-modal',
+  isOpenedByDefault: false,
+})
+
+export function ProjectStepDocumentList({
+  documents,
+  deleteDocumentUrl,
+}: {
+  documents: ProjectStepDocumentJson[]
+  deleteDocumentUrl?: string
+}) {
+  const [documentIdToDelete, setDocumentIdToDelete] = useState<number | null>(null)
+
+  return (
+    <div className="bg-white">
+      <FileItemsList
+        files={documents.map((document) => ({
+          name: document.name,
+          href: document.href,
+          size: document.sizeInBytes,
+          format: 'PDF',
+          deletable: deleteDocumentUrl !== undefined,
+        }))}
+        onDelete={(_, index) => {
+          if (!deleteDocumentUrl) return
+
+          setDocumentIdToDelete(documents[index].id)
+          deleteDocumentModal.open()
+        }}
+      />
+      <deleteDocumentModal.Component
+        title=""
+        size="large"
+        buttons={[
+          { children: 'Annuler', doClosesModal: true, type: 'button' },
+          {
+            children: 'Supprimer le document',
+            onClick: () => {
+              if (!deleteDocumentUrl) return
+
+              router.delete(deleteDocumentUrl, {
+                data: { documentId: documentIdToDelete },
+                onSuccess: () => {
+                  setDocumentIdToDelete(null)
+                },
+              })
+            },
+            type: 'button',
+          },
+        ]}
+      >
+        <Alert
+          severity="error"
+          title="Suppression d'un document"
+          description="Vous êtes sur le point de supprimer ce document, voulez-vous continuer ?"
+        />
+      </deleteDocumentModal.Component>
+    </div>
+  )
+}

--- a/inertia/components/projets/steps-list.tsx
+++ b/inertia/components/projets/steps-list.tsx
@@ -98,6 +98,14 @@ export default function StepsList({ steps, projectId }: StepsListProps) {
             content: `Créée le ${new Date(step.createdAt).toLocaleDateString()}`,
             iconId: 'fr-icon-calendar-event-line',
           },
+          ...(step.documents && step.documents.length > 0
+            ? [
+                {
+                  content: `${step.documents.length} fichier${step.documents.length > 1 ? 's' : ''}`,
+                  iconId: 'fr-icon-attachment-line',
+                },
+              ]
+            : []),
         ]}
         actions={actions}
       />

--- a/inertia/pages/projets/etapes/creation.tsx
+++ b/inertia/pages/projets/etapes/creation.tsx
@@ -1,30 +1,35 @@
 import Layout from '~/ui/layouts/layout'
-import { FormEvent } from 'react'
+import { FormEvent, useRef } from 'react'
 import { Head, router, useForm } from '@inertiajs/react'
 import { Breadcrumb } from '@codegouvfr/react-dsfr/Breadcrumb'
 import { Button } from '@codegouvfr/react-dsfr/Button'
 import { fr } from '@codegouvfr/react-dsfr'
 import { Alert } from '@codegouvfr/react-dsfr/Alert'
+import { Upload } from '@codegouvfr/react-dsfr/Upload'
 import TruncatedText from '~/ui/TruncatedText'
-import ProjectsController from '#controllers/projects_controller'
 import { InferPageProps } from '@adonisjs/inertia/types'
 import ProjectStepForm from '~/components/projets/form/project-step-form'
+import ProjectStepsController from '#controllers/project_steps_controller'
+import SmallSection from '~/ui/SmallSection'
 
 export type ProjectStepFormData = {
   id?: string
   title: string
   note: string
   date: string
+  documents?: File[]
 }
 
 export default function ProjectStepCreationPage({
   projet,
   createStepUrl,
-}: InferPageProps<ProjectsController, 'createStepForm'>) {
+}: InferPageProps<ProjectStepsController, 'createStepForm'>) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const { data, setData, post, resetAndClearErrors } = useForm<ProjectStepFormData>({
     title: '',
     note: '',
     date: '',
+    documents: [],
   })
 
   const handleSubmit = (e: FormEvent) => {
@@ -44,7 +49,7 @@ export default function ProjectStepCreationPage({
         <div className="fr-container">
           <Breadcrumb
             className="fr-my-1w fr-py-1w"
-            currentPageLabel="Nouvelle tâche"
+            currentPageLabel="Nouvelle étape"
             homeLinkProps={{ href: '/' }}
             segments={[
               {
@@ -60,11 +65,59 @@ export default function ProjectStepCreationPage({
         <Alert
           small
           severity="info"
-          description="Veuillez remplir au moins un de ces champs pour créer la tâche."
+          description="Veuillez remplir au moins un de ces champs pour créer l'étape."
         />
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <ProjectStepForm data={data} setData={setData} />
+          <div className="grid grid-cols-[320px_1fr] gap-4">
+            <aside className="flex flex-col gap-4">
+              <SmallSection
+                title="Documents"
+                iconId="fr-icon-attachment-line"
+                hasBorder
+                priority="secondary"
+              >
+                <div className="flex flex-col gap-2">
+                  <Upload
+                    label=""
+                    hint="Format PDF, maximum 10 Mo"
+                    multiple={true}
+                    className="flex-1 border-2 font-bold border-dashed border-[var(--border-default-grey)] fr-p-1w text-sm"
+                    nativeInputProps={{
+                      accept: 'application/pdf',
+                      ref: fileInputRef,
+                      onChange: (e) => {
+                        if (e.target.files) {
+                          const files: File[] = []
+                          for (let i = 0; i < e.target.files.length; i++) {
+                            files.push(e.target.files[i])
+                          }
+                          setData('documents', files)
+                        }
+                      },
+                    }}
+                  />
+                  <Button
+                    size="small"
+                    type="button"
+                    priority="tertiary"
+                    disabled={!data.documents || data.documents.length === 0}
+                    style={{ width: '100%', justifyContent: 'center' }}
+                    onClick={() => {
+                      setData('documents', [])
+                      if (fileInputRef.current) {
+                        fileInputRef.current.files = new DataTransfer().files
+                      }
+                    }}
+                  >
+                    Réinitialiser la sélection
+                  </Button>
+                </div>
+              </SmallSection>
+            </aside>
+
+            <ProjectStepForm data={data} setData={setData} />
+          </div>
 
           <div className="flex w-full items-center justify-end gap-3">
             <Button

--- a/inertia/pages/projets/etapes/edition.tsx
+++ b/inertia/pages/projets/etapes/edition.tsx
@@ -3,25 +3,32 @@ import { Head, router, useForm } from '@inertiajs/react'
 import { Breadcrumb } from '@codegouvfr/react-dsfr/Breadcrumb'
 import { Button } from '@codegouvfr/react-dsfr/Button'
 import { fr } from '@codegouvfr/react-dsfr'
+import { Upload } from '@codegouvfr/react-dsfr/Upload'
 import { FlashMessages } from '~/components/flash-message'
 import TruncatedText from '~/ui/TruncatedText'
-import ProjectsController from '#controllers/projects_controller'
 import { InferPageProps } from '@adonisjs/inertia/types'
 import ProjectStepForm from '~/components/projets/form/project-step-form'
 import type { ProjectStepFormData } from '~/pages/projets/etapes/creation'
 import { getProjectStepTitle } from '~/functions/project_steps'
+import ProjectStepsController from '#controllers/project_steps_controller'
+import SmallSection from '~/ui/SmallSection'
+import { ProjectStepDocumentList } from '~/components/projets/ProjectStepDocumentList'
+import { useRef } from 'react'
 
 export default function ProjectStepEditionPage({
   projet,
   step,
   editStepUrl,
+  deleteDocumentUrl,
   flashMessages,
-}: InferPageProps<ProjectsController, 'getStepForEdition'>) {
+}: InferPageProps<ProjectStepsController, 'getStepForEdition'>) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const { data, setData, patch, resetAndClearErrors } = useForm<ProjectStepFormData>({
     id: step.id,
     title: step.title || '',
     note: step.note || '',
     date: step.date?.slice(0, 10) || '',
+    documents: [],
   })
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -40,7 +47,7 @@ export default function ProjectStepEditionPage({
         <div className="fr-container">
           <Breadcrumb
             className="fr-my-1w fr-py-1w"
-            currentPageLabel="Édition de la tâche"
+            currentPageLabel="Édition de l'étape"
             homeLinkProps={{ href: '/' }}
             segments={[
               {
@@ -62,7 +69,67 @@ export default function ProjectStepEditionPage({
         <FlashMessages flashMessages={flashMessages} />
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <ProjectStepForm data={data} setData={setData} />
+          <div className="grid grid-cols-[320px_1fr] gap-4">
+            <aside className="flex flex-col gap-4">
+              <SmallSection
+                title="Documents"
+                iconId="fr-icon-attachment-line"
+                hasBorder
+                priority="secondary"
+              >
+                <div className="flex flex-col gap-2">
+                  <Upload
+                    label=""
+                    hint="Format PDF, maximum 10 Mo"
+                    multiple={true}
+                    className="flex-1 border-2 font-bold border-dashed border-[var(--border-default-grey)] fr-p-1w text-sm"
+                    nativeInputProps={{
+                      accept: 'application/pdf',
+                      ref: fileInputRef,
+                      onChange: (e) => {
+                        if (e.target.files) {
+                          const files: File[] = []
+                          for (let i = 0; i < e.target.files.length; i++) {
+                            files.push(e.target.files[i])
+                          }
+                          setData('documents', files)
+                        }
+                      },
+                    }}
+                  />
+                  <Button
+                    size="small"
+                    type="button"
+                    priority="tertiary"
+                    disabled={!data.documents || data.documents.length === 0}
+                    style={{ width: '100%', justifyContent: 'center' }}
+                    onClick={() => {
+                      setData('documents', [])
+                      if (fileInputRef.current) {
+                        fileInputRef.current.files = new DataTransfer().files
+                      }
+                    }}
+                  >
+                    Réinitialiser la sélection
+                  </Button>
+                </div>
+
+                {step.documents && step.documents.length > 0 && (
+                  <div className="fr-mt-3w flex flex-col gap-2">
+                    <div className="fr-mt-2w fr-mb-1w text-sm font-bold">
+                      Fichiers déjà téléchargés :
+                    </div>
+                    <ProjectStepDocumentList
+                      documents={step.documents}
+                      deleteDocumentUrl={deleteDocumentUrl}
+                    />
+                  </div>
+                )}
+              </SmallSection>
+            </aside>
+
+            <ProjectStepForm data={data} setData={setData} />
+          </div>
 
           <div className="flex w-full items-center justify-end gap-3">
             <Button

--- a/inertia/pages/projets/etapes/id.tsx
+++ b/inertia/pages/projets/etapes/id.tsx
@@ -11,6 +11,7 @@ import SectionCard from '~/ui/SectionCard'
 import { getProjectStepTitle } from '~/functions/project_steps'
 import type { ProjectStepJson } from '#types/models'
 import StepInfoCard from '~/components/projets/step-info-card'
+import { ProjectStepDocumentList } from '~/components/projets/ProjectStepDocumentList'
 
 type SingleProjectStepProps = {
   projet: {
@@ -20,6 +21,7 @@ type SingleProjectStepProps = {
   step: ProjectStepJson
   deleteStepUrl: string
   completeStepUrl: string
+  deleteDocumentUrl: string
 }
 
 export default function SingleProjectStep({
@@ -27,6 +29,7 @@ export default function SingleProjectStep({
   step,
   deleteStepUrl,
   completeStepUrl,
+  deleteDocumentUrl,
 }: SingleProjectStepProps) {
   const deleteStepModal = createModal({
     id: 'delete-project-step-page-modal',
@@ -77,6 +80,7 @@ export default function SingleProjectStep({
       </div>
 
       <div className="fr-container fr-mt-4w fr-mb-4w">
+        <h2>{stepTitle}</h2>
         <section className="grid grid-cols-[350px_1fr] gap-4">
           <aside className="flex flex-col gap-4">
             <StepInfoCard step={step} completeStepUrl={completeStepUrl} />
@@ -111,18 +115,20 @@ export default function SingleProjectStep({
             </deleteStepModal.Component>
           </aside>
 
-          <SectionCard title={stepTitle} hideLongTitleTooltip>
-            <div className="flex flex-col gap-10">
-              <SectionCard
-                size="small"
-                background="secondary"
-                icon="fr-icon-draft-line"
-                title="Notes"
-              >
-                <p>{step.note || <i>Aucune note enregistrée.</i>}</p>
+          <div className="flex flex-col gap-4">
+            <SectionCard size="small" icon="fr-icon-draft-line" title="Description">
+              <p>{step.note || <i>Aucune note enregistrée.</i>}</p>
+            </SectionCard>
+
+            {step.documents && step.documents.length > 0 && (
+              <SectionCard size="small" icon="fr-icon-attachment-line" title="Documents">
+                <ProjectStepDocumentList
+                  documents={step.documents}
+                  deleteDocumentUrl={deleteDocumentUrl}
+                />
               </SectionCard>
-            </div>
-          </SectionCard>
+            )}
+          </div>
         </section>
       </div>
     </Layout>

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -17,6 +17,7 @@ const LogEntriesController = () => import('#controllers/log_entries_controller')
 const VisualisationController = () => import('#controllers/visualisation_controller')
 const AacController = () => import('#controllers/aac_controller')
 const ProjectsController = () => import('#controllers/projects_controller')
+const ProjectStepsController = () => import('#controllers/project_steps_controller')
 const TerritoiresController = () => import('#controllers/territoires_controller')
 
 router.get('/', ({ response }) => response.redirect('login')).as('root')
@@ -230,38 +231,38 @@ router
         router.patch('projets/:projectId', [ProjectsController, 'update']).as('projets.update')
         router.delete('projets/:projectId', [ProjectsController, 'destroy']).as('projets.destroy')
         router
-          .get('projets/:projectId/etapes/creation', [ProjectsController, 'createStepForm'])
+          .get('projets/:projectId/etapes/creation', [ProjectStepsController, 'createStepForm'])
           .as('projets.steps.create.form')
         router
-          .get('projets/:projectId/etapes/:stepId', [ProjectsController, 'getStep'])
+          .get('projets/:projectId/etapes/:stepId', [ProjectStepsController, 'getStep'])
           .as('projets.steps.get')
         router
           .get('projets/:projectId/etapes/:stepId/edition', [
-            ProjectsController,
+            ProjectStepsController,
             'getStepForEdition',
           ])
           .as('projets.steps.edition')
         router
-          .post('projets/:projectId/etapes', [ProjectsController, 'createStep'])
+          .post('projets/:projectId/etapes', [ProjectStepsController, 'createStep'])
           .as('projets.steps.create')
         router
-          .post('projets/:projectId/etapes/complete', [ProjectsController, 'completeStep'])
+          .post('projets/:projectId/etapes/complete', [ProjectStepsController, 'completeStep'])
           .as('projets.steps.complete')
         router
-          .patch('projets/:projectId/etapes/:stepId', [ProjectsController, 'editStep'])
+          .patch('projets/:projectId/etapes/:stepId', [ProjectStepsController, 'editStep'])
           .as('projets.steps.edit')
         router
-          .delete('projets/:projectId/etapes/:stepId', [ProjectsController, 'destroyStep'])
+          .delete('projets/:projectId/etapes/:stepId', [ProjectStepsController, 'destroyStep'])
           .as('projets.steps.destroy')
         router
           .get('projets/:projectId/etapes/:stepId/documents/:documentId', [
-            ProjectsController,
+            ProjectStepsController,
             'downloadStepDocument',
           ])
           .as('projets.steps.documents.download')
         router
           .delete('projets/:projectId/etapes/:stepId/documents', [
-            ProjectsController,
+            ProjectStepsController,
             'destroyDocument',
           ])
           .as('projets.steps.documents.destroy')


### PR DESCRIPTION
Cette PR ajoute la mise en ligne et la suppression de documents PDF pour chaque étape de projet.

<img width="1256" height="748" alt="image" src="https://github.com/user-attachments/assets/405e7d0f-8d68-42ac-b9d1-858eb72c9265" />

Au passage, le layout de la page étape a été modifié pour mieux correspondre aux maquettes, et les méthodes liés à la gestion des étapes de projets dans le controlleur ProjectsController ont été déplacés dans un ProjectStepsController pour éviter d'avoir un fichier trop long.

Lié à #388 